### PR TITLE
Implement Type Converters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ build/
 .settings
 .last_build_id
 *.iml
+.vscode/

--- a/examples/drift/lib/main.dart
+++ b/examples/drift/lib/main.dart
@@ -1,5 +1,5 @@
-import 'package:auto_mappr_drift_example/db.dart';
-import 'package:auto_mappr_drift_example/mappr.dart';
+import 'package:examples_drift/db.dart';
+import 'package:examples_drift/mappr.dart';
 
 void main() {
   final mappr = Mappr();

--- a/examples/drift/lib/mappr.dart
+++ b/examples/drift/lib/mappr.dart
@@ -1,5 +1,5 @@
 import 'package:auto_mappr_annotation/auto_mappr_annotation.dart';
-import 'package:auto_mappr_drift_example/db.dart';
+import 'package:examples_drift/db.dart';
 
 part 'mappr.g.dart';
 

--- a/examples/drift/lib/mappr.g.dart
+++ b/examples/drift/lib/mappr.g.dart
@@ -11,7 +11,7 @@ part of 'mappr.dart';
 // ignore_for_file: require_trailing_commas, unnecessary_parenthesis
 // ignore_for_file: unnecessary_raw_strings
 
-/// {@template package:auto_mappr_drift_example/mappr.dart}
+/// {@template package:examples_drift/mappr.dart}
 /// Available mappings:
 /// - `Todo` → `TodoItem`.
 /// {@endtemplate}
@@ -22,14 +22,14 @@ class $Mappr {
   ///
   /// When source model is null, returns `whenSourceIsNull` if defined or throws an exception.
   ///
-  /// {@macro package:auto_mappr_drift_example/mappr.dart}
+  /// {@macro package:examples_drift/mappr.dart}
   TARGET convert<SOURCE, TARGET>(SOURCE? model) => _convert(model)!;
 
   /// Converts from SOURCE to TARGET if such mapping is configured.
   ///
   /// When source model is null, returns `whenSourceIsNull` if defined or null.
   ///
-  /// {@macro package:auto_mappr_drift_example/mappr.dart}
+  /// {@macro package:examples_drift/mappr.dart}
   TARGET? tryConvert<SOURCE, TARGET>(SOURCE? model) => _convert(
         model,
         canReturnNull: true,
@@ -39,7 +39,7 @@ class $Mappr {
   ///
   /// When an item in the source iterable is null, uses `whenSourceIsNull` if defined or throws an exception.
   ///
-  /// {@macro package:auto_mappr_drift_example/mappr.dart}
+  /// {@macro package:examples_drift/mappr.dart}
   Iterable<TARGET> convertIterable<SOURCE, TARGET>(Iterable<SOURCE?> model) =>
       model.map<TARGET>((item) => _convert(item)!);
 
@@ -47,7 +47,7 @@ class $Mappr {
   ///
   /// When an item in the source iterable is null, uses `whenSourceIsNull` if defined or null
   ///
-  /// {@macro package:auto_mappr_drift_example/mappr.dart}
+  /// {@macro package:examples_drift/mappr.dart}
   Iterable<TARGET?> tryConvertIterable<SOURCE, TARGET>(
           Iterable<SOURCE?> model) =>
       model.map<TARGET?>((item) => _convert(item, canReturnNull: true));
@@ -56,7 +56,7 @@ class $Mappr {
   ///
   /// When an item in the source iterable is null, uses `whenSourceIsNull` if defined or throws an exception.
   ///
-  /// {@macro package:auto_mappr_drift_example/mappr.dart}
+  /// {@macro package:examples_drift/mappr.dart}
   List<TARGET> convertList<SOURCE, TARGET>(Iterable<SOURCE?> model) =>
       convertIterable<SOURCE, TARGET>(model).toList();
 
@@ -64,7 +64,7 @@ class $Mappr {
   ///
   /// When an item in the source iterable is null, uses `whenSourceIsNull` if defined or null
   ///
-  /// {@macro package:auto_mappr_drift_example/mappr.dart}
+  /// {@macro package:examples_drift/mappr.dart}
   List<TARGET?> tryConvertList<SOURCE, TARGET>(Iterable<SOURCE?> model) =>
       tryConvertIterable<SOURCE, TARGET>(model).toList();
 
@@ -72,7 +72,7 @@ class $Mappr {
   ///
   /// When an item in the source iterable is null, uses `whenSourceIsNull` if defined or throws an exception.
   ///
-  /// {@macro package:auto_mappr_drift_example/mappr.dart}
+  /// {@macro package:examples_drift/mappr.dart}
   Set<TARGET> convertSet<SOURCE, TARGET>(Iterable<SOURCE?> model) =>
       convertIterable<SOURCE, TARGET>(model).toSet();
 
@@ -80,7 +80,7 @@ class $Mappr {
   ///
   /// When an item in the source iterable is null, uses `whenSourceIsNull` if defined or null
   ///
-  /// {@macro package:auto_mappr_drift_example/mappr.dart}
+  /// {@macro package:examples_drift/mappr.dart}
   Set<TARGET?> tryConvertSet<SOURCE, TARGET>(Iterable<SOURCE?> model) =>
       tryConvertIterable<SOURCE, TARGET>(model).toSet();
   TARGET? _convert<SOURCE, TARGET>(
@@ -95,12 +95,12 @@ class $Mappr {
       if (canReturnNull && model == null) {
         return null;
       }
-      return (_map_Todo_To_TodoItem((model as Todo?)) as TARGET);
+      return (_map__Todo__To__TodoItem((model as Todo?)) as TARGET);
     }
     throw Exception('No ${model.runtimeType} -> $targetTypeOf mapping.');
   }
 
-  TodoItem _map_Todo_To_TodoItem(Todo? input) {
+  TodoItem _map__Todo__To__TodoItem(Todo? input) {
     final model = input;
     if (model == null) {
       throw Exception(

--- a/examples/drift/lib/mappr.g.dart
+++ b/examples/drift/lib/mappr.g.dart
@@ -8,8 +8,8 @@ part of 'mappr.dart';
 
 // ignore_for_file: non_constant_identifier_names, prefer_const_constructors
 // ignore_for_file: prefer_const_literals_to_create_immutables
-// ignore_for_file: require_trailing_commas, unnecessary_parenthesis
-// ignore_for_file: unnecessary_raw_strings
+// ignore_for_file: require_trailing_commas, unnecessary_lambdas
+// ignore_for_file: unnecessary_parenthesis, unnecessary_raw_strings
 
 /// {@template package:examples_drift/mappr.dart}
 /// Available mappings:

--- a/examples/drift/pubspec.yaml
+++ b/examples/drift/pubspec.yaml
@@ -1,4 +1,4 @@
-name: auto_mappr_drift_example
+name: examples_drift
 description: Example project with AutoMappr and Drift integration
 version: 1.0.0
 publish_to: none

--- a/examples/example/lib/enum.g.dart
+++ b/examples/example/lib/enum.g.dart
@@ -8,8 +8,8 @@ part of 'enum.dart';
 
 // ignore_for_file: non_constant_identifier_names, prefer_const_constructors
 // ignore_for_file: prefer_const_literals_to_create_immutables
-// ignore_for_file: require_trailing_commas, unnecessary_parenthesis
-// ignore_for_file: unnecessary_raw_strings
+// ignore_for_file: require_trailing_commas, unnecessary_lambdas
+// ignore_for_file: unnecessary_parenthesis, unnecessary_raw_strings
 
 /// {@template package:examples_example/enum.dart}
 /// Available mappings:

--- a/examples/example/lib/enum.g.dart
+++ b/examples/example/lib/enum.g.dart
@@ -11,7 +11,7 @@ part of 'enum.dart';
 // ignore_for_file: require_trailing_commas, unnecessary_parenthesis
 // ignore_for_file: unnecessary_raw_strings
 
-/// {@template package:auto_mappr_example_another/enum.dart}
+/// {@template package:examples_example/enum.dart}
 /// Available mappings:
 /// - `UserType` → `PersonType`.
 /// - `Vehicle` → `Vehicle`.
@@ -24,14 +24,14 @@ class $Mappr {
   ///
   /// When source model is null, returns `whenSourceIsNull` if defined or throws an exception.
   ///
-  /// {@macro package:auto_mappr_example_another/enum.dart}
+  /// {@macro package:examples_example/enum.dart}
   TARGET convert<SOURCE, TARGET>(SOURCE? model) => _convert(model)!;
 
   /// Converts from SOURCE to TARGET if such mapping is configured.
   ///
   /// When source model is null, returns `whenSourceIsNull` if defined or null.
   ///
-  /// {@macro package:auto_mappr_example_another/enum.dart}
+  /// {@macro package:examples_example/enum.dart}
   TARGET? tryConvert<SOURCE, TARGET>(SOURCE? model) => _convert(
         model,
         canReturnNull: true,
@@ -41,7 +41,7 @@ class $Mappr {
   ///
   /// When an item in the source iterable is null, uses `whenSourceIsNull` if defined or throws an exception.
   ///
-  /// {@macro package:auto_mappr_example_another/enum.dart}
+  /// {@macro package:examples_example/enum.dart}
   Iterable<TARGET> convertIterable<SOURCE, TARGET>(Iterable<SOURCE?> model) =>
       model.map<TARGET>((item) => _convert(item)!);
 
@@ -49,7 +49,7 @@ class $Mappr {
   ///
   /// When an item in the source iterable is null, uses `whenSourceIsNull` if defined or null
   ///
-  /// {@macro package:auto_mappr_example_another/enum.dart}
+  /// {@macro package:examples_example/enum.dart}
   Iterable<TARGET?> tryConvertIterable<SOURCE, TARGET>(
           Iterable<SOURCE?> model) =>
       model.map<TARGET?>((item) => _convert(item, canReturnNull: true));
@@ -58,7 +58,7 @@ class $Mappr {
   ///
   /// When an item in the source iterable is null, uses `whenSourceIsNull` if defined or throws an exception.
   ///
-  /// {@macro package:auto_mappr_example_another/enum.dart}
+  /// {@macro package:examples_example/enum.dart}
   List<TARGET> convertList<SOURCE, TARGET>(Iterable<SOURCE?> model) =>
       convertIterable<SOURCE, TARGET>(model).toList();
 
@@ -66,7 +66,7 @@ class $Mappr {
   ///
   /// When an item in the source iterable is null, uses `whenSourceIsNull` if defined or null
   ///
-  /// {@macro package:auto_mappr_example_another/enum.dart}
+  /// {@macro package:examples_example/enum.dart}
   List<TARGET?> tryConvertList<SOURCE, TARGET>(Iterable<SOURCE?> model) =>
       tryConvertIterable<SOURCE, TARGET>(model).toList();
 
@@ -74,7 +74,7 @@ class $Mappr {
   ///
   /// When an item in the source iterable is null, uses `whenSourceIsNull` if defined or throws an exception.
   ///
-  /// {@macro package:auto_mappr_example_another/enum.dart}
+  /// {@macro package:examples_example/enum.dart}
   Set<TARGET> convertSet<SOURCE, TARGET>(Iterable<SOURCE?> model) =>
       convertIterable<SOURCE, TARGET>(model).toSet();
 
@@ -82,7 +82,7 @@ class $Mappr {
   ///
   /// When an item in the source iterable is null, uses `whenSourceIsNull` if defined or null
   ///
-  /// {@macro package:auto_mappr_example_another/enum.dart}
+  /// {@macro package:examples_example/enum.dart}
   Set<TARGET?> tryConvertSet<SOURCE, TARGET>(Iterable<SOURCE?> model) =>
       tryConvertIterable<SOURCE, TARGET>(model).toSet();
   TARGET? _convert<SOURCE, TARGET>(
@@ -98,7 +98,7 @@ class $Mappr {
       if (canReturnNull && model == null) {
         return null;
       }
-      return (_map_UserType_To_PersonType((model as UserType?)) as TARGET);
+      return (_map__UserType__To__PersonType((model as UserType?)) as TARGET);
     }
     if ((sourceTypeOf == _typeOf<Vehicle>() ||
             sourceTypeOf == _typeOf<Vehicle?>()) &&
@@ -107,7 +107,7 @@ class $Mappr {
       if (canReturnNull && model == null) {
         return null;
       }
-      return (_map_Vehicle_To_Vehicle((model as Vehicle?)) as TARGET);
+      return (_map__Vehicle__To__Vehicle((model as Vehicle?)) as TARGET);
     }
     if ((sourceTypeOf == _typeOf<Vehicle>() ||
             sourceTypeOf == _typeOf<Vehicle?>()) &&
@@ -116,12 +116,12 @@ class $Mappr {
       if (canReturnNull && model == null) {
         return null;
       }
-      return (_map_Vehicle_To_VehicleX((model as Vehicle?)) as TARGET);
+      return (_map__Vehicle__To__VehicleX((model as Vehicle?)) as TARGET);
     }
     throw Exception('No ${model.runtimeType} -> $targetTypeOf mapping.');
   }
 
-  PersonType _map_UserType_To_PersonType(UserType? input) {
+  PersonType _map__UserType__To__PersonType(UserType? input) {
     final model = input;
     if (model == null) {
       throw Exception(
@@ -131,7 +131,7 @@ class $Mappr {
     return PersonType.values.firstWhere((x) => x.name == model.name);
   }
 
-  Vehicle _map_Vehicle_To_Vehicle(Vehicle? input) {
+  Vehicle _map__Vehicle__To__Vehicle(Vehicle? input) {
     final model = input;
     if (model == null) {
       throw Exception(
@@ -141,7 +141,7 @@ class $Mappr {
     return Vehicle.values.firstWhere((x) => x.name == model.name);
   }
 
-  VehicleX _map_Vehicle_To_VehicleX(Vehicle? input) {
+  VehicleX _map__Vehicle__To__VehicleX(Vehicle? input) {
     final model = input;
     if (model == null) {
       throw Exception(

--- a/examples/example/lib/equatable.g.dart
+++ b/examples/example/lib/equatable.g.dart
@@ -8,8 +8,8 @@ part of 'equatable.dart';
 
 // ignore_for_file: non_constant_identifier_names, prefer_const_constructors
 // ignore_for_file: prefer_const_literals_to_create_immutables
-// ignore_for_file: require_trailing_commas, unnecessary_parenthesis
-// ignore_for_file: unnecessary_raw_strings
+// ignore_for_file: require_trailing_commas, unnecessary_lambdas
+// ignore_for_file: unnecessary_parenthesis, unnecessary_raw_strings
 
 /// {@template package:examples_example/equatable.dart}
 /// Available mappings:

--- a/examples/example/lib/equatable.g.dart
+++ b/examples/example/lib/equatable.g.dart
@@ -11,7 +11,7 @@ part of 'equatable.dart';
 // ignore_for_file: require_trailing_commas, unnecessary_parenthesis
 // ignore_for_file: unnecessary_raw_strings
 
-/// {@template package:auto_mappr_example_another/equatable.dart}
+/// {@template package:examples_example/equatable.dart}
 /// Available mappings:
 /// - `UserDto` → `User`.
 /// {@endtemplate}
@@ -22,14 +22,14 @@ class $Mappr {
   ///
   /// When source model is null, returns `whenSourceIsNull` if defined or throws an exception.
   ///
-  /// {@macro package:auto_mappr_example_another/equatable.dart}
+  /// {@macro package:examples_example/equatable.dart}
   TARGET convert<SOURCE, TARGET>(SOURCE? model) => _convert(model)!;
 
   /// Converts from SOURCE to TARGET if such mapping is configured.
   ///
   /// When source model is null, returns `whenSourceIsNull` if defined or null.
   ///
-  /// {@macro package:auto_mappr_example_another/equatable.dart}
+  /// {@macro package:examples_example/equatable.dart}
   TARGET? tryConvert<SOURCE, TARGET>(SOURCE? model) => _convert(
         model,
         canReturnNull: true,
@@ -39,7 +39,7 @@ class $Mappr {
   ///
   /// When an item in the source iterable is null, uses `whenSourceIsNull` if defined or throws an exception.
   ///
-  /// {@macro package:auto_mappr_example_another/equatable.dart}
+  /// {@macro package:examples_example/equatable.dart}
   Iterable<TARGET> convertIterable<SOURCE, TARGET>(Iterable<SOURCE?> model) =>
       model.map<TARGET>((item) => _convert(item)!);
 
@@ -47,7 +47,7 @@ class $Mappr {
   ///
   /// When an item in the source iterable is null, uses `whenSourceIsNull` if defined or null
   ///
-  /// {@macro package:auto_mappr_example_another/equatable.dart}
+  /// {@macro package:examples_example/equatable.dart}
   Iterable<TARGET?> tryConvertIterable<SOURCE, TARGET>(
           Iterable<SOURCE?> model) =>
       model.map<TARGET?>((item) => _convert(item, canReturnNull: true));
@@ -56,7 +56,7 @@ class $Mappr {
   ///
   /// When an item in the source iterable is null, uses `whenSourceIsNull` if defined or throws an exception.
   ///
-  /// {@macro package:auto_mappr_example_another/equatable.dart}
+  /// {@macro package:examples_example/equatable.dart}
   List<TARGET> convertList<SOURCE, TARGET>(Iterable<SOURCE?> model) =>
       convertIterable<SOURCE, TARGET>(model).toList();
 
@@ -64,7 +64,7 @@ class $Mappr {
   ///
   /// When an item in the source iterable is null, uses `whenSourceIsNull` if defined or null
   ///
-  /// {@macro package:auto_mappr_example_another/equatable.dart}
+  /// {@macro package:examples_example/equatable.dart}
   List<TARGET?> tryConvertList<SOURCE, TARGET>(Iterable<SOURCE?> model) =>
       tryConvertIterable<SOURCE, TARGET>(model).toList();
 
@@ -72,7 +72,7 @@ class $Mappr {
   ///
   /// When an item in the source iterable is null, uses `whenSourceIsNull` if defined or throws an exception.
   ///
-  /// {@macro package:auto_mappr_example_another/equatable.dart}
+  /// {@macro package:examples_example/equatable.dart}
   Set<TARGET> convertSet<SOURCE, TARGET>(Iterable<SOURCE?> model) =>
       convertIterable<SOURCE, TARGET>(model).toSet();
 
@@ -80,7 +80,7 @@ class $Mappr {
   ///
   /// When an item in the source iterable is null, uses `whenSourceIsNull` if defined or null
   ///
-  /// {@macro package:auto_mappr_example_another/equatable.dart}
+  /// {@macro package:examples_example/equatable.dart}
   Set<TARGET?> tryConvertSet<SOURCE, TARGET>(Iterable<SOURCE?> model) =>
       tryConvertIterable<SOURCE, TARGET>(model).toSet();
   TARGET? _convert<SOURCE, TARGET>(
@@ -95,12 +95,12 @@ class $Mappr {
       if (canReturnNull && model == null) {
         return null;
       }
-      return (_map_UserDto_To_User((model as UserDto?)) as TARGET);
+      return (_map__UserDto__To__User((model as UserDto?)) as TARGET);
     }
     throw Exception('No ${model.runtimeType} -> $targetTypeOf mapping.');
   }
 
-  User _map_UserDto_To_User(UserDto? input) {
+  User _map__UserDto__To__User(UserDto? input) {
     final model = input;
     if (model == null) {
       throw Exception(

--- a/examples/example/lib/main.dart
+++ b/examples/example/lib/main.dart
@@ -1,4 +1,4 @@
-import 'package:auto_mappr_example_another/equatable.dart';
+import 'package:examples_example/equatable.dart';
 
 void main() {
   final dto = UserDto(id: 123, name: 'Peter', age: 42);

--- a/examples/example/lib/nested.g.dart
+++ b/examples/example/lib/nested.g.dart
@@ -8,8 +8,8 @@ part of 'nested.dart';
 
 // ignore_for_file: non_constant_identifier_names, prefer_const_constructors
 // ignore_for_file: prefer_const_literals_to_create_immutables
-// ignore_for_file: require_trailing_commas, unnecessary_parenthesis
-// ignore_for_file: unnecessary_raw_strings
+// ignore_for_file: require_trailing_commas, unnecessary_lambdas
+// ignore_for_file: unnecessary_parenthesis, unnecessary_raw_strings
 
 /// {@template package:examples_example/nested.dart}
 /// Available mappings:

--- a/examples/example/lib/nested.g.dart
+++ b/examples/example/lib/nested.g.dart
@@ -11,7 +11,7 @@ part of 'nested.dart';
 // ignore_for_file: require_trailing_commas, unnecessary_parenthesis
 // ignore_for_file: unnecessary_raw_strings
 
-/// {@template package:auto_mappr_example_another/nested.dart}
+/// {@template package:examples_example/nested.dart}
 /// Available mappings:
 /// - `UserDto` → `User`.
 /// - `NestedDto` → `Nested`.
@@ -24,14 +24,14 @@ class $Mappr {
   ///
   /// When source model is null, returns `whenSourceIsNull` if defined or throws an exception.
   ///
-  /// {@macro package:auto_mappr_example_another/nested.dart}
+  /// {@macro package:examples_example/nested.dart}
   TARGET convert<SOURCE, TARGET>(SOURCE? model) => _convert(model)!;
 
   /// Converts from SOURCE to TARGET if such mapping is configured.
   ///
   /// When source model is null, returns `whenSourceIsNull` if defined or null.
   ///
-  /// {@macro package:auto_mappr_example_another/nested.dart}
+  /// {@macro package:examples_example/nested.dart}
   TARGET? tryConvert<SOURCE, TARGET>(SOURCE? model) => _convert(
         model,
         canReturnNull: true,
@@ -41,7 +41,7 @@ class $Mappr {
   ///
   /// When an item in the source iterable is null, uses `whenSourceIsNull` if defined or throws an exception.
   ///
-  /// {@macro package:auto_mappr_example_another/nested.dart}
+  /// {@macro package:examples_example/nested.dart}
   Iterable<TARGET> convertIterable<SOURCE, TARGET>(Iterable<SOURCE?> model) =>
       model.map<TARGET>((item) => _convert(item)!);
 
@@ -49,7 +49,7 @@ class $Mappr {
   ///
   /// When an item in the source iterable is null, uses `whenSourceIsNull` if defined or null
   ///
-  /// {@macro package:auto_mappr_example_another/nested.dart}
+  /// {@macro package:examples_example/nested.dart}
   Iterable<TARGET?> tryConvertIterable<SOURCE, TARGET>(
           Iterable<SOURCE?> model) =>
       model.map<TARGET?>((item) => _convert(item, canReturnNull: true));
@@ -58,7 +58,7 @@ class $Mappr {
   ///
   /// When an item in the source iterable is null, uses `whenSourceIsNull` if defined or throws an exception.
   ///
-  /// {@macro package:auto_mappr_example_another/nested.dart}
+  /// {@macro package:examples_example/nested.dart}
   List<TARGET> convertList<SOURCE, TARGET>(Iterable<SOURCE?> model) =>
       convertIterable<SOURCE, TARGET>(model).toList();
 
@@ -66,7 +66,7 @@ class $Mappr {
   ///
   /// When an item in the source iterable is null, uses `whenSourceIsNull` if defined or null
   ///
-  /// {@macro package:auto_mappr_example_another/nested.dart}
+  /// {@macro package:examples_example/nested.dart}
   List<TARGET?> tryConvertList<SOURCE, TARGET>(Iterable<SOURCE?> model) =>
       tryConvertIterable<SOURCE, TARGET>(model).toList();
 
@@ -74,7 +74,7 @@ class $Mappr {
   ///
   /// When an item in the source iterable is null, uses `whenSourceIsNull` if defined or throws an exception.
   ///
-  /// {@macro package:auto_mappr_example_another/nested.dart}
+  /// {@macro package:examples_example/nested.dart}
   Set<TARGET> convertSet<SOURCE, TARGET>(Iterable<SOURCE?> model) =>
       convertIterable<SOURCE, TARGET>(model).toSet();
 
@@ -82,7 +82,7 @@ class $Mappr {
   ///
   /// When an item in the source iterable is null, uses `whenSourceIsNull` if defined or null
   ///
-  /// {@macro package:auto_mappr_example_another/nested.dart}
+  /// {@macro package:examples_example/nested.dart}
   Set<TARGET?> tryConvertSet<SOURCE, TARGET>(Iterable<SOURCE?> model) =>
       tryConvertIterable<SOURCE, TARGET>(model).toSet();
   TARGET? _convert<SOURCE, TARGET>(
@@ -97,7 +97,7 @@ class $Mappr {
       if (canReturnNull && model == null) {
         return null;
       }
-      return (_map_UserDto_To_User((model as UserDto?)) as TARGET);
+      return (_map__UserDto__To__User((model as UserDto?)) as TARGET);
     }
     if ((sourceTypeOf == _typeOf<NestedDto>() ||
             sourceTypeOf == _typeOf<NestedDto?>()) &&
@@ -106,7 +106,7 @@ class $Mappr {
       if (canReturnNull && model == null) {
         return null;
       }
-      return (_map_NestedDto_To_Nested((model as NestedDto?)) as TARGET);
+      return (_map__NestedDto__To__Nested((model as NestedDto?)) as TARGET);
     }
     if ((sourceTypeOf == _typeOf<NestedTagDto>() ||
             sourceTypeOf == _typeOf<NestedTagDto?>()) &&
@@ -115,13 +115,13 @@ class $Mappr {
       if (canReturnNull && model == null) {
         return null;
       }
-      return (_map_NestedTagDto_To_NestedTag((model as NestedTagDto?))
+      return (_map__NestedTagDto__To__NestedTag((model as NestedTagDto?))
           as TARGET);
     }
     throw Exception('No ${model.runtimeType} -> $targetTypeOf mapping.');
   }
 
-  User _map_UserDto_To_User(UserDto? input) {
+  User _map__UserDto__To__User(UserDto? input) {
     final model = input;
     if (model == null) {
       throw Exception(
@@ -130,28 +130,28 @@ class $Mappr {
     }
     return User(
       id: model.id,
-      name: _map_NestedDto_To_Nested(model.name),
+      name: _map__NestedDto__To__Nested(model.name),
       nestedItems:
-          model.nestedItems.map<Nested>(_map_NestedDto_To_Nested).toList(),
+          model.nestedItems.map<Nested>(_map__NestedDto__To__Nested).toList(),
       nestedItemsNullable: model.nestedItemsNullable
-              ?.map<Nested>(_map_NestedDto_To_Nested)
+              ?.map<Nested>(_map__NestedDto__To__Nested)
               .toList() ??
           <Nested>[],
       nestedItemsNullable2: model.nestedItemsNullable2
-          .map<Nested>(_map_NestedDto_To_Nested)
+          .map<Nested>(_map__NestedDto__To__Nested)
           .toList(),
       itemsWithNullableItem: model.itemsWithNullableItem
           .whereNotNull()
-          .map<Nested>(_map_NestedDto_To_Nested)
+          .map<Nested>(_map__NestedDto__To__Nested)
           .toList(),
       itemsWithNullableItem2: model.itemsWithNullableItem2
-          .map<Nested?>(_map_NestedDto_To_Nested_Nullable)
+          .map<Nested?>(_map__NestedDto__To__Nested_Nullable)
           .toList(),
       tag: null,
     );
   }
 
-  Nested _map_NestedDto_To_Nested(NestedDto? input) {
+  Nested _map__NestedDto__To__Nested(NestedDto? input) {
     final model = input;
     if (model == null) {
       throw Exception(
@@ -161,11 +161,11 @@ class $Mappr {
     return Nested(
       id: model.id,
       name: model.name,
-      tag: _map_NestedTagDto_To_NestedTag(model.tag),
+      tag: _map__NestedTagDto__To__NestedTag(model.tag),
     );
   }
 
-  NestedTag _map_NestedTagDto_To_NestedTag(NestedTagDto? input) {
+  NestedTag _map__NestedTagDto__To__NestedTag(NestedTagDto? input) {
     final model = input;
     if (model == null) {
       throw Exception(
@@ -175,7 +175,7 @@ class $Mappr {
     return NestedTag();
   }
 
-  Nested? _map_NestedDto_To_Nested_Nullable(NestedDto? input) {
+  Nested? _map__NestedDto__To__Nested_Nullable(NestedDto? input) {
     final model = input;
     if (model == null) {
       return null;
@@ -183,7 +183,7 @@ class $Mappr {
     return Nested(
       id: model.id,
       name: model.name,
-      tag: _map_NestedTagDto_To_NestedTag(model.tag),
+      tag: _map__NestedTagDto__To__NestedTag(model.tag),
     );
   }
 }

--- a/examples/example/lib/nullable.g.dart
+++ b/examples/example/lib/nullable.g.dart
@@ -11,7 +11,7 @@ part of 'nullable.dart';
 // ignore_for_file: require_trailing_commas, unnecessary_parenthesis
 // ignore_for_file: unnecessary_raw_strings
 
-/// {@template package:auto_mappr_example_another/nullable.dart}
+/// {@template package:examples_example/nullable.dart}
 /// Available mappings:
 /// - `UserDto` → `User` -- With default value.
 /// - `NestedDto` → `Nested`.
@@ -23,14 +23,14 @@ class $Mappr {
   ///
   /// When source model is null, returns `whenSourceIsNull` if defined or throws an exception.
   ///
-  /// {@macro package:auto_mappr_example_another/nullable.dart}
+  /// {@macro package:examples_example/nullable.dart}
   TARGET convert<SOURCE, TARGET>(SOURCE? model) => _convert(model)!;
 
   /// Converts from SOURCE to TARGET if such mapping is configured.
   ///
   /// When source model is null, returns `whenSourceIsNull` if defined or null.
   ///
-  /// {@macro package:auto_mappr_example_another/nullable.dart}
+  /// {@macro package:examples_example/nullable.dart}
   TARGET? tryConvert<SOURCE, TARGET>(SOURCE? model) => _convert(
         model,
         canReturnNull: true,
@@ -40,7 +40,7 @@ class $Mappr {
   ///
   /// When an item in the source iterable is null, uses `whenSourceIsNull` if defined or throws an exception.
   ///
-  /// {@macro package:auto_mappr_example_another/nullable.dart}
+  /// {@macro package:examples_example/nullable.dart}
   Iterable<TARGET> convertIterable<SOURCE, TARGET>(Iterable<SOURCE?> model) =>
       model.map<TARGET>((item) => _convert(item)!);
 
@@ -48,7 +48,7 @@ class $Mappr {
   ///
   /// When an item in the source iterable is null, uses `whenSourceIsNull` if defined or null
   ///
-  /// {@macro package:auto_mappr_example_another/nullable.dart}
+  /// {@macro package:examples_example/nullable.dart}
   Iterable<TARGET?> tryConvertIterable<SOURCE, TARGET>(
           Iterable<SOURCE?> model) =>
       model.map<TARGET?>((item) => _convert(item, canReturnNull: true));
@@ -57,7 +57,7 @@ class $Mappr {
   ///
   /// When an item in the source iterable is null, uses `whenSourceIsNull` if defined or throws an exception.
   ///
-  /// {@macro package:auto_mappr_example_another/nullable.dart}
+  /// {@macro package:examples_example/nullable.dart}
   List<TARGET> convertList<SOURCE, TARGET>(Iterable<SOURCE?> model) =>
       convertIterable<SOURCE, TARGET>(model).toList();
 
@@ -65,7 +65,7 @@ class $Mappr {
   ///
   /// When an item in the source iterable is null, uses `whenSourceIsNull` if defined or null
   ///
-  /// {@macro package:auto_mappr_example_another/nullable.dart}
+  /// {@macro package:examples_example/nullable.dart}
   List<TARGET?> tryConvertList<SOURCE, TARGET>(Iterable<SOURCE?> model) =>
       tryConvertIterable<SOURCE, TARGET>(model).toList();
 
@@ -73,7 +73,7 @@ class $Mappr {
   ///
   /// When an item in the source iterable is null, uses `whenSourceIsNull` if defined or throws an exception.
   ///
-  /// {@macro package:auto_mappr_example_another/nullable.dart}
+  /// {@macro package:examples_example/nullable.dart}
   Set<TARGET> convertSet<SOURCE, TARGET>(Iterable<SOURCE?> model) =>
       convertIterable<SOURCE, TARGET>(model).toSet();
 
@@ -81,7 +81,7 @@ class $Mappr {
   ///
   /// When an item in the source iterable is null, uses `whenSourceIsNull` if defined or null
   ///
-  /// {@macro package:auto_mappr_example_another/nullable.dart}
+  /// {@macro package:examples_example/nullable.dart}
   Set<TARGET?> tryConvertSet<SOURCE, TARGET>(Iterable<SOURCE?> model) =>
       tryConvertIterable<SOURCE, TARGET>(model).toSet();
   TARGET? _convert<SOURCE, TARGET>(
@@ -102,7 +102,7 @@ class $Mappr {
           ),
         ) as TARGET);
       }
-      return (_map_UserDto_To_User((model as UserDto?)) as TARGET);
+      return (_map__UserDto__To__User((model as UserDto?)) as TARGET);
     }
     if ((sourceTypeOf == _typeOf<NestedDto>() ||
             sourceTypeOf == _typeOf<NestedDto?>()) &&
@@ -111,12 +111,12 @@ class $Mappr {
       if (canReturnNull && model == null) {
         return null;
       }
-      return (_map_NestedDto_To_Nested((model as NestedDto?)) as TARGET);
+      return (_map__NestedDto__To__Nested((model as NestedDto?)) as TARGET);
     }
     throw Exception('No ${model.runtimeType} -> $targetTypeOf mapping.');
   }
 
-  User _map_UserDto_To_User(UserDto? input) {
+  User _map__UserDto__To__User(UserDto? input) {
     final model = input;
     if (model == null) {
       return const User(
@@ -131,12 +131,12 @@ class $Mappr {
       id: model.id,
       tag: model.tag == null
           ? Mappr.defaultNested()
-          : _map_NestedDto_To_Nested(model.tag),
-      name: _map_NestedDto_To_Nested(model.name),
+          : _map__NestedDto__To__Nested(model.tag),
+      name: _map__NestedDto__To__Nested(model.name),
     );
   }
 
-  Nested _map_NestedDto_To_Nested(NestedDto? input) {
+  Nested _map__NestedDto__To__Nested(NestedDto? input) {
     final model = input;
     if (model == null) {
       throw Exception(

--- a/examples/example/lib/nullable.g.dart
+++ b/examples/example/lib/nullable.g.dart
@@ -8,8 +8,8 @@ part of 'nullable.dart';
 
 // ignore_for_file: non_constant_identifier_names, prefer_const_constructors
 // ignore_for_file: prefer_const_literals_to_create_immutables
-// ignore_for_file: require_trailing_commas, unnecessary_parenthesis
-// ignore_for_file: unnecessary_raw_strings
+// ignore_for_file: require_trailing_commas, unnecessary_lambdas
+// ignore_for_file: unnecessary_parenthesis, unnecessary_raw_strings
 
 /// {@template package:examples_example/nullable.dart}
 /// Available mappings:

--- a/examples/example/lib/rename.g.dart
+++ b/examples/example/lib/rename.g.dart
@@ -8,8 +8,8 @@ part of 'rename.dart';
 
 // ignore_for_file: non_constant_identifier_names, prefer_const_constructors
 // ignore_for_file: prefer_const_literals_to_create_immutables
-// ignore_for_file: require_trailing_commas, unnecessary_parenthesis
-// ignore_for_file: unnecessary_raw_strings
+// ignore_for_file: require_trailing_commas, unnecessary_lambdas
+// ignore_for_file: unnecessary_parenthesis, unnecessary_raw_strings
 
 /// {@template package:examples_example/rename.dart}
 /// Available mappings:

--- a/examples/example/lib/rename.g.dart
+++ b/examples/example/lib/rename.g.dart
@@ -11,7 +11,7 @@ part of 'rename.dart';
 // ignore_for_file: require_trailing_commas, unnecessary_parenthesis
 // ignore_for_file: unnecessary_raw_strings
 
-/// {@template package:auto_mappr_example_another/rename.dart}
+/// {@template package:examples_example/rename.dart}
 /// Available mappings:
 /// - `UserDto` → `User`.
 /// {@endtemplate}
@@ -22,14 +22,14 @@ class $Mappr {
   ///
   /// When source model is null, returns `whenSourceIsNull` if defined or throws an exception.
   ///
-  /// {@macro package:auto_mappr_example_another/rename.dart}
+  /// {@macro package:examples_example/rename.dart}
   TARGET convert<SOURCE, TARGET>(SOURCE? model) => _convert(model)!;
 
   /// Converts from SOURCE to TARGET if such mapping is configured.
   ///
   /// When source model is null, returns `whenSourceIsNull` if defined or null.
   ///
-  /// {@macro package:auto_mappr_example_another/rename.dart}
+  /// {@macro package:examples_example/rename.dart}
   TARGET? tryConvert<SOURCE, TARGET>(SOURCE? model) => _convert(
         model,
         canReturnNull: true,
@@ -39,7 +39,7 @@ class $Mappr {
   ///
   /// When an item in the source iterable is null, uses `whenSourceIsNull` if defined or throws an exception.
   ///
-  /// {@macro package:auto_mappr_example_another/rename.dart}
+  /// {@macro package:examples_example/rename.dart}
   Iterable<TARGET> convertIterable<SOURCE, TARGET>(Iterable<SOURCE?> model) =>
       model.map<TARGET>((item) => _convert(item)!);
 
@@ -47,7 +47,7 @@ class $Mappr {
   ///
   /// When an item in the source iterable is null, uses `whenSourceIsNull` if defined or null
   ///
-  /// {@macro package:auto_mappr_example_another/rename.dart}
+  /// {@macro package:examples_example/rename.dart}
   Iterable<TARGET?> tryConvertIterable<SOURCE, TARGET>(
           Iterable<SOURCE?> model) =>
       model.map<TARGET?>((item) => _convert(item, canReturnNull: true));
@@ -56,7 +56,7 @@ class $Mappr {
   ///
   /// When an item in the source iterable is null, uses `whenSourceIsNull` if defined or throws an exception.
   ///
-  /// {@macro package:auto_mappr_example_another/rename.dart}
+  /// {@macro package:examples_example/rename.dart}
   List<TARGET> convertList<SOURCE, TARGET>(Iterable<SOURCE?> model) =>
       convertIterable<SOURCE, TARGET>(model).toList();
 
@@ -64,7 +64,7 @@ class $Mappr {
   ///
   /// When an item in the source iterable is null, uses `whenSourceIsNull` if defined or null
   ///
-  /// {@macro package:auto_mappr_example_another/rename.dart}
+  /// {@macro package:examples_example/rename.dart}
   List<TARGET?> tryConvertList<SOURCE, TARGET>(Iterable<SOURCE?> model) =>
       tryConvertIterable<SOURCE, TARGET>(model).toList();
 
@@ -72,7 +72,7 @@ class $Mappr {
   ///
   /// When an item in the source iterable is null, uses `whenSourceIsNull` if defined or throws an exception.
   ///
-  /// {@macro package:auto_mappr_example_another/rename.dart}
+  /// {@macro package:examples_example/rename.dart}
   Set<TARGET> convertSet<SOURCE, TARGET>(Iterable<SOURCE?> model) =>
       convertIterable<SOURCE, TARGET>(model).toSet();
 
@@ -80,7 +80,7 @@ class $Mappr {
   ///
   /// When an item in the source iterable is null, uses `whenSourceIsNull` if defined or null
   ///
-  /// {@macro package:auto_mappr_example_another/rename.dart}
+  /// {@macro package:examples_example/rename.dart}
   Set<TARGET?> tryConvertSet<SOURCE, TARGET>(Iterable<SOURCE?> model) =>
       tryConvertIterable<SOURCE, TARGET>(model).toSet();
   TARGET? _convert<SOURCE, TARGET>(
@@ -95,12 +95,12 @@ class $Mappr {
       if (canReturnNull && model == null) {
         return null;
       }
-      return (_map_UserDto_To_User((model as UserDto?)) as TARGET);
+      return (_map__UserDto__To__User((model as UserDto?)) as TARGET);
     }
     throw Exception('No ${model.runtimeType} -> $targetTypeOf mapping.');
   }
 
-  User _map_UserDto_To_User(UserDto? input) {
+  User _map__UserDto__To__User(UserDto? input) {
     final model = input;
     if (model == null) {
       throw Exception(

--- a/examples/example/pubspec.yaml
+++ b/examples/example/pubspec.yaml
@@ -1,4 +1,4 @@
-name: auto_mappr_example_another
+name: examples_example
 description: Example project how to use AutoMappr
 version: 1.0.0
 publish_to: none

--- a/examples/freezed/lib/freezed_example.g.dart
+++ b/examples/freezed/lib/freezed_example.g.dart
@@ -11,7 +11,7 @@ part of 'freezed_example.dart';
 // ignore_for_file: require_trailing_commas, unnecessary_parenthesis
 // ignore_for_file: unnecessary_raw_strings
 
-/// {@template package:auto_mappr_freezed_example/freezed_example.dart}
+/// {@template package:examples_freezed/freezed_example.dart}
 /// Available mappings:
 /// - `UserInfo` → `UserInfoCompanion`.
 /// {@endtemplate}
@@ -22,14 +22,14 @@ class $Mappr {
   ///
   /// When source model is null, returns `whenSourceIsNull` if defined or throws an exception.
   ///
-  /// {@macro package:auto_mappr_freezed_example/freezed_example.dart}
+  /// {@macro package:examples_freezed/freezed_example.dart}
   TARGET convert<SOURCE, TARGET>(SOURCE? model) => _convert(model)!;
 
   /// Converts from SOURCE to TARGET if such mapping is configured.
   ///
   /// When source model is null, returns `whenSourceIsNull` if defined or null.
   ///
-  /// {@macro package:auto_mappr_freezed_example/freezed_example.dart}
+  /// {@macro package:examples_freezed/freezed_example.dart}
   TARGET? tryConvert<SOURCE, TARGET>(SOURCE? model) => _convert(
         model,
         canReturnNull: true,
@@ -39,7 +39,7 @@ class $Mappr {
   ///
   /// When an item in the source iterable is null, uses `whenSourceIsNull` if defined or throws an exception.
   ///
-  /// {@macro package:auto_mappr_freezed_example/freezed_example.dart}
+  /// {@macro package:examples_freezed/freezed_example.dart}
   Iterable<TARGET> convertIterable<SOURCE, TARGET>(Iterable<SOURCE?> model) =>
       model.map<TARGET>((item) => _convert(item)!);
 
@@ -47,7 +47,7 @@ class $Mappr {
   ///
   /// When an item in the source iterable is null, uses `whenSourceIsNull` if defined or null
   ///
-  /// {@macro package:auto_mappr_freezed_example/freezed_example.dart}
+  /// {@macro package:examples_freezed/freezed_example.dart}
   Iterable<TARGET?> tryConvertIterable<SOURCE, TARGET>(
           Iterable<SOURCE?> model) =>
       model.map<TARGET?>((item) => _convert(item, canReturnNull: true));
@@ -56,7 +56,7 @@ class $Mappr {
   ///
   /// When an item in the source iterable is null, uses `whenSourceIsNull` if defined or throws an exception.
   ///
-  /// {@macro package:auto_mappr_freezed_example/freezed_example.dart}
+  /// {@macro package:examples_freezed/freezed_example.dart}
   List<TARGET> convertList<SOURCE, TARGET>(Iterable<SOURCE?> model) =>
       convertIterable<SOURCE, TARGET>(model).toList();
 
@@ -64,7 +64,7 @@ class $Mappr {
   ///
   /// When an item in the source iterable is null, uses `whenSourceIsNull` if defined or null
   ///
-  /// {@macro package:auto_mappr_freezed_example/freezed_example.dart}
+  /// {@macro package:examples_freezed/freezed_example.dart}
   List<TARGET?> tryConvertList<SOURCE, TARGET>(Iterable<SOURCE?> model) =>
       tryConvertIterable<SOURCE, TARGET>(model).toList();
 
@@ -72,7 +72,7 @@ class $Mappr {
   ///
   /// When an item in the source iterable is null, uses `whenSourceIsNull` if defined or throws an exception.
   ///
-  /// {@macro package:auto_mappr_freezed_example/freezed_example.dart}
+  /// {@macro package:examples_freezed/freezed_example.dart}
   Set<TARGET> convertSet<SOURCE, TARGET>(Iterable<SOURCE?> model) =>
       convertIterable<SOURCE, TARGET>(model).toSet();
 
@@ -80,7 +80,7 @@ class $Mappr {
   ///
   /// When an item in the source iterable is null, uses `whenSourceIsNull` if defined or null
   ///
-  /// {@macro package:auto_mappr_freezed_example/freezed_example.dart}
+  /// {@macro package:examples_freezed/freezed_example.dart}
   Set<TARGET?> tryConvertSet<SOURCE, TARGET>(Iterable<SOURCE?> model) =>
       tryConvertIterable<SOURCE, TARGET>(model).toSet();
   TARGET? _convert<SOURCE, TARGET>(
@@ -96,13 +96,13 @@ class $Mappr {
       if (canReturnNull && model == null) {
         return null;
       }
-      return (_map_UserInfo_To_UserInfoCompanion((model as UserInfo?))
+      return (_map__UserInfo__To__UserInfoCompanion((model as UserInfo?))
           as TARGET);
     }
     throw Exception('No ${model.runtimeType} -> $targetTypeOf mapping.');
   }
 
-  UserInfoCompanion _map_UserInfo_To_UserInfoCompanion(UserInfo? input) {
+  UserInfoCompanion _map__UserInfo__To__UserInfoCompanion(UserInfo? input) {
     final model = input;
     if (model == null) {
       throw Exception(

--- a/examples/freezed/lib/freezed_example.g.dart
+++ b/examples/freezed/lib/freezed_example.g.dart
@@ -8,8 +8,8 @@ part of 'freezed_example.dart';
 
 // ignore_for_file: non_constant_identifier_names, prefer_const_constructors
 // ignore_for_file: prefer_const_literals_to_create_immutables
-// ignore_for_file: require_trailing_commas, unnecessary_parenthesis
-// ignore_for_file: unnecessary_raw_strings
+// ignore_for_file: require_trailing_commas, unnecessary_lambdas
+// ignore_for_file: unnecessary_parenthesis, unnecessary_raw_strings
 
 /// {@template package:examples_freezed/freezed_example.dart}
 /// Available mappings:

--- a/examples/freezed/lib/main.dart
+++ b/examples/freezed/lib/main.dart
@@ -1,4 +1,4 @@
-import 'package:auto_mappr_freezed_example/freezed_example.dart';
+import 'package:examples_freezed/freezed_example.dart';
 
 void main() {
   final union = UserInfo(loginIdentifier: 'user', email: 'test@email.com', updatedAt: DateTime.now());

--- a/examples/freezed/pubspec.yaml
+++ b/examples/freezed/pubspec.yaml
@@ -1,4 +1,4 @@
-name: auto_mappr_freezed_example
+name: examples_freezed
 description: Example project with AutoMappr and Freezed integration
 version: 1.0.0
 publish_to: none

--- a/examples/injectable/lib/getit.config.dart
+++ b/examples/injectable/lib/getit.config.dart
@@ -9,7 +9,7 @@
 // coverage:ignore-file
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'package:auto_mappr_injectable_example/mappr.dart' as _i3;
+import 'package:examples_injectable/mappr.dart' as _i3;
 import 'package:get_it/get_it.dart' as _i1;
 import 'package:injectable/injectable.dart' as _i2;
 

--- a/examples/injectable/lib/getit.dart
+++ b/examples/injectable/lib/getit.dart
@@ -1,4 +1,4 @@
-import 'package:auto_mappr_injectable_example/getit.config.dart';
+import 'package:examples_injectable/getit.config.dart';
 import 'package:get_it/get_it.dart';
 import 'package:injectable/injectable.dart';
 

--- a/examples/injectable/lib/main.dart
+++ b/examples/injectable/lib/main.dart
@@ -1,5 +1,5 @@
-import 'package:auto_mappr_injectable_example/getit.dart';
-import 'package:auto_mappr_injectable_example/mappr.dart';
+import 'package:examples_injectable/getit.dart';
+import 'package:examples_injectable/mappr.dart';
 
 void main() {
   configureDependencies();

--- a/examples/injectable/lib/mappr.g.dart
+++ b/examples/injectable/lib/mappr.g.dart
@@ -11,7 +11,7 @@ part of 'mappr.dart';
 // ignore_for_file: require_trailing_commas, unnecessary_parenthesis
 // ignore_for_file: unnecessary_raw_strings
 
-/// {@template package:auto_mappr_injectable_example/mappr.dart}
+/// {@template package:examples_injectable/mappr.dart}
 /// Available mappings:
 /// - `UserDto` → `User`.
 /// {@endtemplate}
@@ -22,14 +22,14 @@ class $Mappr {
   ///
   /// When source model is null, returns `whenSourceIsNull` if defined or throws an exception.
   ///
-  /// {@macro package:auto_mappr_injectable_example/mappr.dart}
+  /// {@macro package:examples_injectable/mappr.dart}
   TARGET convert<SOURCE, TARGET>(SOURCE? model) => _convert(model)!;
 
   /// Converts from SOURCE to TARGET if such mapping is configured.
   ///
   /// When source model is null, returns `whenSourceIsNull` if defined or null.
   ///
-  /// {@macro package:auto_mappr_injectable_example/mappr.dart}
+  /// {@macro package:examples_injectable/mappr.dart}
   TARGET? tryConvert<SOURCE, TARGET>(SOURCE? model) => _convert(
         model,
         canReturnNull: true,
@@ -39,7 +39,7 @@ class $Mappr {
   ///
   /// When an item in the source iterable is null, uses `whenSourceIsNull` if defined or throws an exception.
   ///
-  /// {@macro package:auto_mappr_injectable_example/mappr.dart}
+  /// {@macro package:examples_injectable/mappr.dart}
   Iterable<TARGET> convertIterable<SOURCE, TARGET>(Iterable<SOURCE?> model) =>
       model.map<TARGET>((item) => _convert(item)!);
 
@@ -47,7 +47,7 @@ class $Mappr {
   ///
   /// When an item in the source iterable is null, uses `whenSourceIsNull` if defined or null
   ///
-  /// {@macro package:auto_mappr_injectable_example/mappr.dart}
+  /// {@macro package:examples_injectable/mappr.dart}
   Iterable<TARGET?> tryConvertIterable<SOURCE, TARGET>(
           Iterable<SOURCE?> model) =>
       model.map<TARGET?>((item) => _convert(item, canReturnNull: true));
@@ -56,7 +56,7 @@ class $Mappr {
   ///
   /// When an item in the source iterable is null, uses `whenSourceIsNull` if defined or throws an exception.
   ///
-  /// {@macro package:auto_mappr_injectable_example/mappr.dart}
+  /// {@macro package:examples_injectable/mappr.dart}
   List<TARGET> convertList<SOURCE, TARGET>(Iterable<SOURCE?> model) =>
       convertIterable<SOURCE, TARGET>(model).toList();
 
@@ -64,7 +64,7 @@ class $Mappr {
   ///
   /// When an item in the source iterable is null, uses `whenSourceIsNull` if defined or null
   ///
-  /// {@macro package:auto_mappr_injectable_example/mappr.dart}
+  /// {@macro package:examples_injectable/mappr.dart}
   List<TARGET?> tryConvertList<SOURCE, TARGET>(Iterable<SOURCE?> model) =>
       tryConvertIterable<SOURCE, TARGET>(model).toList();
 
@@ -72,7 +72,7 @@ class $Mappr {
   ///
   /// When an item in the source iterable is null, uses `whenSourceIsNull` if defined or throws an exception.
   ///
-  /// {@macro package:auto_mappr_injectable_example/mappr.dart}
+  /// {@macro package:examples_injectable/mappr.dart}
   Set<TARGET> convertSet<SOURCE, TARGET>(Iterable<SOURCE?> model) =>
       convertIterable<SOURCE, TARGET>(model).toSet();
 
@@ -80,7 +80,7 @@ class $Mappr {
   ///
   /// When an item in the source iterable is null, uses `whenSourceIsNull` if defined or null
   ///
-  /// {@macro package:auto_mappr_injectable_example/mappr.dart}
+  /// {@macro package:examples_injectable/mappr.dart}
   Set<TARGET?> tryConvertSet<SOURCE, TARGET>(Iterable<SOURCE?> model) =>
       tryConvertIterable<SOURCE, TARGET>(model).toSet();
   TARGET? _convert<SOURCE, TARGET>(
@@ -95,12 +95,12 @@ class $Mappr {
       if (canReturnNull && model == null) {
         return null;
       }
-      return (_map_UserDto_To_User((model as UserDto?)) as TARGET);
+      return (_map__UserDto__To__User((model as UserDto?)) as TARGET);
     }
     throw Exception('No ${model.runtimeType} -> $targetTypeOf mapping.');
   }
 
-  User _map_UserDto_To_User(UserDto? input) {
+  User _map__UserDto__To__User(UserDto? input) {
     final model = input;
     if (model == null) {
       throw Exception(

--- a/examples/injectable/lib/mappr.g.dart
+++ b/examples/injectable/lib/mappr.g.dart
@@ -8,8 +8,8 @@ part of 'mappr.dart';
 
 // ignore_for_file: non_constant_identifier_names, prefer_const_constructors
 // ignore_for_file: prefer_const_literals_to_create_immutables
-// ignore_for_file: require_trailing_commas, unnecessary_parenthesis
-// ignore_for_file: unnecessary_raw_strings
+// ignore_for_file: require_trailing_commas, unnecessary_lambdas
+// ignore_for_file: unnecessary_parenthesis, unnecessary_raw_strings
 
 /// {@template package:examples_injectable/mappr.dart}
 /// Available mappings:

--- a/examples/injectable/pubspec.yaml
+++ b/examples/injectable/pubspec.yaml
@@ -1,4 +1,4 @@
-name: auto_mappr_injectable_example
+name: examples_injectable
 description: Example project how to use AutoMappr with Injectable
 version: 1.0.0
 publish_to: none

--- a/examples/json_serializable/lib/main.dart
+++ b/examples/json_serializable/lib/main.dart
@@ -1,4 +1,4 @@
-import 'package:auto_mappr_json_example/serializable.dart';
+import 'package:examples_json_serializable/serializable.dart';
 
 void main() {
   final mappr = Mappr();

--- a/examples/json_serializable/lib/serializable.g.dart
+++ b/examples/json_serializable/lib/serializable.g.dart
@@ -8,8 +8,8 @@ part of 'serializable.dart';
 
 // ignore_for_file: non_constant_identifier_names, prefer_const_constructors
 // ignore_for_file: prefer_const_literals_to_create_immutables
-// ignore_for_file: require_trailing_commas, unnecessary_parenthesis
-// ignore_for_file: unnecessary_raw_strings
+// ignore_for_file: require_trailing_commas, unnecessary_lambdas
+// ignore_for_file: unnecessary_parenthesis, unnecessary_raw_strings
 
 /// {@template package:examples_json_serializable/serializable.dart}
 /// Available mappings:

--- a/examples/json_serializable/lib/serializable.g.dart
+++ b/examples/json_serializable/lib/serializable.g.dart
@@ -11,7 +11,7 @@ part of 'serializable.dart';
 // ignore_for_file: require_trailing_commas, unnecessary_parenthesis
 // ignore_for_file: unnecessary_raw_strings
 
-/// {@template package:auto_mappr_json_example/serializable.dart}
+/// {@template package:examples_json_serializable/serializable.dart}
 /// Available mappings:
 /// - `UserDto` → `User`.
 /// - `ValueHolderDto` → `ValueHolder`.
@@ -23,14 +23,14 @@ class $Mappr {
   ///
   /// When source model is null, returns `whenSourceIsNull` if defined or throws an exception.
   ///
-  /// {@macro package:auto_mappr_json_example/serializable.dart}
+  /// {@macro package:examples_json_serializable/serializable.dart}
   TARGET convert<SOURCE, TARGET>(SOURCE? model) => _convert(model)!;
 
   /// Converts from SOURCE to TARGET if such mapping is configured.
   ///
   /// When source model is null, returns `whenSourceIsNull` if defined or null.
   ///
-  /// {@macro package:auto_mappr_json_example/serializable.dart}
+  /// {@macro package:examples_json_serializable/serializable.dart}
   TARGET? tryConvert<SOURCE, TARGET>(SOURCE? model) => _convert(
         model,
         canReturnNull: true,
@@ -40,7 +40,7 @@ class $Mappr {
   ///
   /// When an item in the source iterable is null, uses `whenSourceIsNull` if defined or throws an exception.
   ///
-  /// {@macro package:auto_mappr_json_example/serializable.dart}
+  /// {@macro package:examples_json_serializable/serializable.dart}
   Iterable<TARGET> convertIterable<SOURCE, TARGET>(Iterable<SOURCE?> model) =>
       model.map<TARGET>((item) => _convert(item)!);
 
@@ -48,7 +48,7 @@ class $Mappr {
   ///
   /// When an item in the source iterable is null, uses `whenSourceIsNull` if defined or null
   ///
-  /// {@macro package:auto_mappr_json_example/serializable.dart}
+  /// {@macro package:examples_json_serializable/serializable.dart}
   Iterable<TARGET?> tryConvertIterable<SOURCE, TARGET>(
           Iterable<SOURCE?> model) =>
       model.map<TARGET?>((item) => _convert(item, canReturnNull: true));
@@ -57,7 +57,7 @@ class $Mappr {
   ///
   /// When an item in the source iterable is null, uses `whenSourceIsNull` if defined or throws an exception.
   ///
-  /// {@macro package:auto_mappr_json_example/serializable.dart}
+  /// {@macro package:examples_json_serializable/serializable.dart}
   List<TARGET> convertList<SOURCE, TARGET>(Iterable<SOURCE?> model) =>
       convertIterable<SOURCE, TARGET>(model).toList();
 
@@ -65,7 +65,7 @@ class $Mappr {
   ///
   /// When an item in the source iterable is null, uses `whenSourceIsNull` if defined or null
   ///
-  /// {@macro package:auto_mappr_json_example/serializable.dart}
+  /// {@macro package:examples_json_serializable/serializable.dart}
   List<TARGET?> tryConvertList<SOURCE, TARGET>(Iterable<SOURCE?> model) =>
       tryConvertIterable<SOURCE, TARGET>(model).toList();
 
@@ -73,7 +73,7 @@ class $Mappr {
   ///
   /// When an item in the source iterable is null, uses `whenSourceIsNull` if defined or throws an exception.
   ///
-  /// {@macro package:auto_mappr_json_example/serializable.dart}
+  /// {@macro package:examples_json_serializable/serializable.dart}
   Set<TARGET> convertSet<SOURCE, TARGET>(Iterable<SOURCE?> model) =>
       convertIterable<SOURCE, TARGET>(model).toSet();
 
@@ -81,7 +81,7 @@ class $Mappr {
   ///
   /// When an item in the source iterable is null, uses `whenSourceIsNull` if defined or null
   ///
-  /// {@macro package:auto_mappr_json_example/serializable.dart}
+  /// {@macro package:examples_json_serializable/serializable.dart}
   Set<TARGET?> tryConvertSet<SOURCE, TARGET>(Iterable<SOURCE?> model) =>
       tryConvertIterable<SOURCE, TARGET>(model).toSet();
   TARGET? _convert<SOURCE, TARGET>(
@@ -96,7 +96,7 @@ class $Mappr {
       if (canReturnNull && model == null) {
         return null;
       }
-      return (_map_UserDto_To_User((model as UserDto?)) as TARGET);
+      return (_map__UserDto__To__User((model as UserDto?)) as TARGET);
     }
     if ((sourceTypeOf == _typeOf<ValueHolderDto>() ||
             sourceTypeOf == _typeOf<ValueHolderDto?>()) &&
@@ -105,13 +105,13 @@ class $Mappr {
       if (canReturnNull && model == null) {
         return null;
       }
-      return (_map_ValueHolderDto_To_ValueHolder((model as ValueHolderDto?))
+      return (_map__ValueHolderDto__To__ValueHolder((model as ValueHolderDto?))
           as TARGET);
     }
     throw Exception('No ${model.runtimeType} -> $targetTypeOf mapping.');
   }
 
-  User _map_UserDto_To_User(UserDto? input) {
+  User _map__UserDto__To__User(UserDto? input) {
     final model = input;
     if (model == null) {
       throw Exception(
@@ -124,7 +124,7 @@ class $Mappr {
     );
   }
 
-  ValueHolder _map_ValueHolderDto_To_ValueHolder(ValueHolderDto? input) {
+  ValueHolder _map__ValueHolderDto__To__ValueHolder(ValueHolderDto? input) {
     final model = input;
     if (model == null) {
       throw Exception(

--- a/examples/json_serializable/pubspec.yaml
+++ b/examples/json_serializable/pubspec.yaml
@@ -1,4 +1,4 @@
-name: auto_mappr_json_example
+name: examples_json_serializable
 description: Example project with AutoMappr and JsonSerializable
 version: 1.0.0
 publish_to: none

--- a/examples/json_serializable/test/fixture/json_serializable.g.dart
+++ b/examples/json_serializable/test/fixture/json_serializable.g.dart
@@ -11,7 +11,7 @@ part of 'json_serializable.dart';
 // ignore_for_file: require_trailing_commas, unnecessary_parenthesis
 // ignore_for_file: unnecessary_raw_strings
 
-/// {@template asset:auto_mappr_json_example/test/fixture/json_serializable.dart}
+/// {@template asset:examples_json_serializable/test/fixture/json_serializable.dart}
 /// Available mappings:
 /// - `UserDto` → `User`.
 /// - `ValueHolderDto` → `ValueHolder`.
@@ -23,14 +23,14 @@ class $Mappr {
   ///
   /// When source model is null, returns `whenSourceIsNull` if defined or throws an exception.
   ///
-  /// {@macro asset:auto_mappr_json_example/test/fixture/json_serializable.dart}
+  /// {@macro asset:examples_json_serializable/test/fixture/json_serializable.dart}
   TARGET convert<SOURCE, TARGET>(SOURCE? model) => _convert(model)!;
 
   /// Converts from SOURCE to TARGET if such mapping is configured.
   ///
   /// When source model is null, returns `whenSourceIsNull` if defined or null.
   ///
-  /// {@macro asset:auto_mappr_json_example/test/fixture/json_serializable.dart}
+  /// {@macro asset:examples_json_serializable/test/fixture/json_serializable.dart}
   TARGET? tryConvert<SOURCE, TARGET>(SOURCE? model) => _convert(
         model,
         canReturnNull: true,
@@ -40,7 +40,7 @@ class $Mappr {
   ///
   /// When an item in the source iterable is null, uses `whenSourceIsNull` if defined or throws an exception.
   ///
-  /// {@macro asset:auto_mappr_json_example/test/fixture/json_serializable.dart}
+  /// {@macro asset:examples_json_serializable/test/fixture/json_serializable.dart}
   Iterable<TARGET> convertIterable<SOURCE, TARGET>(Iterable<SOURCE?> model) =>
       model.map<TARGET>((item) => _convert(item)!);
 
@@ -48,7 +48,7 @@ class $Mappr {
   ///
   /// When an item in the source iterable is null, uses `whenSourceIsNull` if defined or null
   ///
-  /// {@macro asset:auto_mappr_json_example/test/fixture/json_serializable.dart}
+  /// {@macro asset:examples_json_serializable/test/fixture/json_serializable.dart}
   Iterable<TARGET?> tryConvertIterable<SOURCE, TARGET>(
           Iterable<SOURCE?> model) =>
       model.map<TARGET?>((item) => _convert(item, canReturnNull: true));
@@ -57,7 +57,7 @@ class $Mappr {
   ///
   /// When an item in the source iterable is null, uses `whenSourceIsNull` if defined or throws an exception.
   ///
-  /// {@macro asset:auto_mappr_json_example/test/fixture/json_serializable.dart}
+  /// {@macro asset:examples_json_serializable/test/fixture/json_serializable.dart}
   List<TARGET> convertList<SOURCE, TARGET>(Iterable<SOURCE?> model) =>
       convertIterable<SOURCE, TARGET>(model).toList();
 
@@ -65,7 +65,7 @@ class $Mappr {
   ///
   /// When an item in the source iterable is null, uses `whenSourceIsNull` if defined or null
   ///
-  /// {@macro asset:auto_mappr_json_example/test/fixture/json_serializable.dart}
+  /// {@macro asset:examples_json_serializable/test/fixture/json_serializable.dart}
   List<TARGET?> tryConvertList<SOURCE, TARGET>(Iterable<SOURCE?> model) =>
       tryConvertIterable<SOURCE, TARGET>(model).toList();
 
@@ -73,7 +73,7 @@ class $Mappr {
   ///
   /// When an item in the source iterable is null, uses `whenSourceIsNull` if defined or throws an exception.
   ///
-  /// {@macro asset:auto_mappr_json_example/test/fixture/json_serializable.dart}
+  /// {@macro asset:examples_json_serializable/test/fixture/json_serializable.dart}
   Set<TARGET> convertSet<SOURCE, TARGET>(Iterable<SOURCE?> model) =>
       convertIterable<SOURCE, TARGET>(model).toSet();
 
@@ -81,7 +81,7 @@ class $Mappr {
   ///
   /// When an item in the source iterable is null, uses `whenSourceIsNull` if defined or null
   ///
-  /// {@macro asset:auto_mappr_json_example/test/fixture/json_serializable.dart}
+  /// {@macro asset:examples_json_serializable/test/fixture/json_serializable.dart}
   Set<TARGET?> tryConvertSet<SOURCE, TARGET>(Iterable<SOURCE?> model) =>
       tryConvertIterable<SOURCE, TARGET>(model).toSet();
   TARGET? _convert<SOURCE, TARGET>(
@@ -96,7 +96,7 @@ class $Mappr {
       if (canReturnNull && model == null) {
         return null;
       }
-      return (_map_UserDto_To_User((model as UserDto?)) as TARGET);
+      return (_map__UserDto__To__User((model as UserDto?)) as TARGET);
     }
     if ((sourceTypeOf == _typeOf<ValueHolderDto>() ||
             sourceTypeOf == _typeOf<ValueHolderDto?>()) &&
@@ -105,13 +105,13 @@ class $Mappr {
       if (canReturnNull && model == null) {
         return null;
       }
-      return (_map_ValueHolderDto_To_ValueHolder((model as ValueHolderDto?))
+      return (_map__ValueHolderDto__To__ValueHolder((model as ValueHolderDto?))
           as TARGET);
     }
     throw Exception('No ${model.runtimeType} -> $targetTypeOf mapping.');
   }
 
-  User _map_UserDto_To_User(UserDto? input) {
+  User _map__UserDto__To__User(UserDto? input) {
     final model = input;
     if (model == null) {
       throw Exception(
@@ -124,7 +124,7 @@ class $Mappr {
     );
   }
 
-  ValueHolder _map_ValueHolderDto_To_ValueHolder(ValueHolderDto? input) {
+  ValueHolder _map__ValueHolderDto__To__ValueHolder(ValueHolderDto? input) {
     final model = input;
     if (model == null) {
       throw Exception(

--- a/examples/json_serializable/test/fixture/json_serializable.g.dart
+++ b/examples/json_serializable/test/fixture/json_serializable.g.dart
@@ -8,8 +8,8 @@ part of 'json_serializable.dart';
 
 // ignore_for_file: non_constant_identifier_names, prefer_const_constructors
 // ignore_for_file: prefer_const_literals_to_create_immutables
-// ignore_for_file: require_trailing_commas, unnecessary_parenthesis
-// ignore_for_file: unnecessary_raw_strings
+// ignore_for_file: require_trailing_commas, unnecessary_lambdas
+// ignore_for_file: unnecessary_parenthesis, unnecessary_raw_strings
 
 /// {@template asset:examples_json_serializable/test/fixture/json_serializable.dart}
 /// Available mappings:

--- a/packages/auto_mappr/CHANGELOG.md
+++ b/packages/auto_mappr/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+- Add support for library aliases,
+so mapping now supports types from different libraries with the same name.
+
 ## 1.3.1
 - Add documentation for enums and converting iterables. [#52](https://github.com/netglade/auto_mappr/pull/52)
 - Fix generator when multiple annotations are used. [#51](https://github.com/netglade/auto_mappr/pull/51)

--- a/packages/auto_mappr/README.md
+++ b/packages/auto_mappr/README.md
@@ -41,6 +41,7 @@ Heavily inspired by [C# AutoMapper][auto_mapper_net_link].
     * ✅ [Mapping from source](#mapping-from-source)
     * ✅ [Nullability handling](#nullability-handling)
     * ✅ [Generics](#generics)
+    * ✅ [Library import aliases](#library-import-aliases)
     * ✅ [Works with `equatable`](#works-with-equatable)
     * ✅ [Works with `json_serializable`](#works-with-jsonserializable)
     * ✅ [Works with generated source and target classes](#works-with-generated-source-and-target-classes)
@@ -461,6 +462,26 @@ class Nested<X, Y> {
 // ...
 }
 ```
+
+### Library import aliases
+
+In cases when you have two libraries with classes with the same name,
+mapping works as expected by using import aliases.
+
+```dart
+import 'my_api.dart' as api;
+import 'my_domain.dart' as entity;
+
+@AutoMappr([
+  MapType<api.User, entity.User>(),
+])
+class Mappr extends $Mappr {}
+```
+
+Note that importing a list of `MapType` from another library
+and putting it inside `@AutoMappr` annotation is not possible,
+since we cannot generate the type correctly (it can overlap with something else)
+while using shared part builder.
 
 ### Works with `equatable`
 

--- a/packages/auto_mappr/example/lib/mappr.g.dart
+++ b/packages/auto_mappr/example/lib/mappr.g.dart
@@ -95,12 +95,12 @@ class $Mappr {
       if (canReturnNull && model == null) {
         return null;
       }
-      return (_map_UserDto_To_User((model as UserDto?)) as TARGET);
+      return (_map__UserDto__To__User((model as UserDto?)) as TARGET);
     }
     throw Exception('No ${model.runtimeType} -> $targetTypeOf mapping.');
   }
 
-  User _map_UserDto_To_User(UserDto? input) {
+  User _map__UserDto__To__User(UserDto? input) {
     final model = input;
     if (model == null) {
       throw Exception(

--- a/packages/auto_mappr/lib/src/builder/auto_mappr_builder.dart
+++ b/packages/auto_mappr/lib/src/builder/auto_mappr_builder.dart
@@ -4,6 +4,7 @@
 import 'package:analyzer/dart/element/element.dart';
 import 'package:auto_mappr/src/builder/convert_method_builder.dart';
 import 'package:auto_mappr/src/builder/map_model_body_method_builder.dart';
+import 'package:auto_mappr/src/extensions/dart_type_extension.dart';
 import 'package:auto_mappr/src/models/auto_mappr_config.dart';
 import 'package:built_collection/built_collection.dart';
 import 'package:code_builder/code_builder.dart';
@@ -78,15 +79,17 @@ class AutoMapprBuilder {
       for (final mapping in config.mappers)
         Method(
           (b) => b
-            ..name = mapping.mappingMethodName
+            ..name = mapping.mappingMethodName(config: config)
             ..requiredParameters.addAll([
               Parameter(
                 (p) => p
                   ..name = 'input'
-                  ..type = refer('${mapping.source.getDisplayString(withNullability: false)}?'),
+                  ..type = refer('${mapping.source.getDisplayStringWithLibraryAlias(config: config)}?'),
               )
             ])
-            ..returns = refer(mapping.target.getDisplayString(withNullability: false))
+            ..returns = refer(
+              mapping.target.getDisplayStringWithLibraryAlias(config: config),
+            )
             ..body = MapModelBodyMethodBuilder(
               mapping: mapping,
               mapperConfig: config,
@@ -98,15 +101,18 @@ class AutoMapprBuilder {
       for (final mapping in config.mappers.where(convertMethodBuilder.shouldGenerateNullableMappingMethod))
         Method(
           (b) => b
-            ..name = mapping.nullableMappingMethodName
+            ..name = mapping.nullableMappingMethodName(config: config)
             ..requiredParameters.addAll([
               Parameter(
                 (p) => p
                   ..name = 'input'
-                  ..type = refer('${mapping.source.getDisplayString(withNullability: false)}?'),
+                  ..type = refer('${mapping.source.getDisplayStringWithLibraryAlias(config: config)}?'),
               )
             ])
-            ..returns = refer('${mapping.target.getDisplayString(withNullability: true)}?')
+            ..returns = refer('${mapping.target.getDisplayStringWithLibraryAlias(
+              withNullability: true,
+              config: config,
+            )}?')
             ..body = MapModelBodyMethodBuilder(
               mapping: mapping,
               mapperConfig: config,

--- a/packages/auto_mappr/lib/src/builder/enum_assignment_builder.dart
+++ b/packages/auto_mappr/lib/src/builder/enum_assignment_builder.dart
@@ -1,4 +1,5 @@
 import 'package:analyzer/dart/element/element.dart';
+import 'package:auto_mappr/src/extensions/dart_type_extension.dart';
 import 'package:auto_mappr/src/models/models.dart';
 import 'package:code_builder/code_builder.dart';
 import 'package:source_gen/source_gen.dart';
@@ -18,7 +19,11 @@ class EnumAssignmentBuilder {
     // Check that both source and target enums are enums.
     if (!isSourceEnum || !isTargetEnum) {
       throw InvalidGenerationSourceError(
-        'Failed to map $mapping because ${isSourceEnum ? 'target ${mapping.targetName()}' : 'source ${mapping.sourceName()}'} is not an enum.',
+        'Failed to map $mapping because ${isSourceEnum ? 'target ${mapping.target.getDisplayStringWithLibraryAlias(
+            config: mapperConfig,
+          )}' : 'source ${mapping.source.getDisplayStringWithLibraryAlias(
+            config: mapperConfig,
+          )}'} is not an enum.',
       );
     }
 
@@ -32,11 +37,15 @@ class EnumAssignmentBuilder {
 
     if (!sourceIsSubset) {
       throw InvalidGenerationSourceError(
-        "Can't map enum ${mapping.sourceName()} into ${mapping.targetName()}. Target enum is not superset of source enum.",
+        "Can't map enum ${mapping.source.getDisplayStringWithLibraryAlias(
+          config: mapperConfig,
+        )} into ${mapping.target.getDisplayStringWithLibraryAlias(
+          config: mapperConfig,
+        )}. Target enum is not superset of source enum.",
       );
     }
 
-    final targetReference = refer(mapping.targetName());
+    final targetReference = refer(mapping.target.getDisplayStringWithLibraryAlias(config: mapperConfig));
 
     return targetReference
         .property('values')

--- a/packages/auto_mappr/lib/src/builder/map_model_body_method_builder.dart
+++ b/packages/auto_mappr/lib/src/builder/map_model_body_method_builder.dart
@@ -212,16 +212,30 @@ class MapModelBodyMethodBuilder {
           );
         }
 
-        notMappedTargetParameters.add(
-          SourceAssignment(
+        if(fieldMapping?.hasWhenNullDefault() ?? false) {
+          final sourceAssignment = SourceAssignment(
             sourceField: null,
             targetField: targetField,
-            fieldMapping: fieldMapping,
             targetConstructorParam: constructorAssignment,
+            fieldMapping: fieldMapping,
             typeMapping: mapping,
             config: mapperConfig,
-          ),
-        );
+          );
+
+          mappedTargetConstructorParams.add(sourceAssignment);
+          mappedSourceFieldNames.add(param.name);
+        } else {
+          notMappedTargetParameters.add(
+            SourceAssignment(
+              sourceField: null,
+              targetField: targetField,
+              fieldMapping: fieldMapping,
+              targetConstructorParam: constructorAssignment,
+              typeMapping: mapping,
+              config: mapperConfig,
+            ),
+          );
+        }
       }
     }
 

--- a/packages/auto_mappr/lib/src/builder/map_model_body_method_builder.dart
+++ b/packages/auto_mappr/lib/src/builder/map_model_body_method_builder.dart
@@ -3,6 +3,7 @@ import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:auto_mappr/src/builder/enum_assignment_builder.dart';
 import 'package:auto_mappr/src/builder/value_assignment_builder.dart';
+import 'package:auto_mappr/src/extensions/element_extension.dart';
 import 'package:auto_mappr/src/extensions/expression_extension.dart';
 import 'package:auto_mappr/src/extensions/interface_type_extension.dart';
 import 'package:auto_mappr/src/models/models.dart';
@@ -151,6 +152,7 @@ class MapModelBodyMethodBuilder {
           targetConstructorParam: constructorAssignment,
           fieldMapping: mapping.tryGetFieldMapping(targetField.displayName),
           typeMapping: mapping,
+          config: mapperConfig,
         );
 
         mappedTargetConstructorParams.add(sourceAssignment);
@@ -176,6 +178,7 @@ class MapModelBodyMethodBuilder {
           targetConstructorParam: constructorAssignment,
           fieldMapping: mapping.tryGetFieldMapping(targetField.displayName),
           typeMapping: mapping,
+          config: mapperConfig,
         );
 
         mappedTargetConstructorParams.add(sourceAssignment);
@@ -202,6 +205,7 @@ class MapModelBodyMethodBuilder {
             fieldMapping: fieldMapping,
             targetConstructorParam: constructorAssignment,
             typeMapping: mapping,
+            config: mapperConfig,
           ),
         );
       }
@@ -236,7 +240,11 @@ class MapModelBodyMethodBuilder {
     required List<SourceAssignment> positional,
     required List<SourceAssignment> named,
   }) {
-    return refer(targetConstructor.displayName).newInstance(
+    final alias = targetConstructor.enclosingElement.getLibraryAlias(config: mapperConfig);
+    final connectionString = alias.trim().isEmpty ? '' : '.';
+    final constructorName = targetConstructor.displayName;
+
+    return refer('$alias$connectionString$constructorName').newInstance(
       positional.map(
         (assignment) => ValueAssignmentBuilder(
           mapperConfig: mapperConfig,
@@ -293,6 +301,7 @@ class MapModelBodyMethodBuilder {
                 sourceField: sourceField,
                 targetField: targetField,
                 typeMapping: mapping,
+                config: mapperConfig,
               ),
               usedNullableMethodCallback: usedNullableMethodCallback,
             ).build(),

--- a/packages/auto_mappr/lib/src/builder/value_assignment_builder.dart
+++ b/packages/auto_mappr/lib/src/builder/value_assignment_builder.dart
@@ -225,7 +225,14 @@ class ValueAssignmentBuilder {
         withNullability: true,
         config: mapperConfig,
       );
-      final sourceName = assignment.sourceField?.getDisplayString(withNullability: true);
+
+      if (assignment.hasTypeConversion()) {
+        return assignment.getTypeConversion().apply(assignment);
+      }
+
+      if(mapperConfig.hasTypeConversion(assignment)) {
+        return mapperConfig.getTypeConversion(assignment).apply(assignment);
+      }
 
       if (target.nullabilitySuffix == NullabilitySuffix.question) {
         log.warning("Can't find nested mapping '$assignment' but target is nullable. Setting null");
@@ -233,6 +240,7 @@ class ValueAssignmentBuilder {
         return literalNull;
       }
 
+      final sourceName = assignment.sourceField?.getDisplayString(withNullability: true);
       throw InvalidGenerationSourceError(
         'Trying to map nested object from "$assignment" but no mapping is configured.',
         todo: 'Configure mapping from $sourceName to $targetTypeName',

--- a/packages/auto_mappr/lib/src/builder/value_assignment_builder.dart
+++ b/packages/auto_mappr/lib/src/builder/value_assignment_builder.dart
@@ -46,14 +46,11 @@ class ValueAssignmentBuilder {
       return _assignMapValue(assignment);
     }
 
-    final rightSide =
-        refer(sourceField.isStatic ? '${sourceField.enclosingElement.name}' : 'model').property(sourceField.name);
-
       return _assignNestedObject(
         source: assignment.sourceType!,
         target: assignment.targetType,
         assignment: assignment,
-        convertMethodArgument: rightSide,
+        convertMethodArgument: assignment.sourceExpression,
       );
   }
 
@@ -73,7 +70,7 @@ class ValueAssignmentBuilder {
     final assignNestedObject = !targetIterableType.isPrimitiveType && (!targetIterableType.isAssignableTo(sourceIterableType));
 
     // When [sourceIterableType] is nullable and [targetIterableType] is not, remove null values.
-    final sourceIterableExpression = refer('model').property(assignment.sourceField!.name).maybeWhereIterableNotNull(
+    final sourceIterableExpression = refer('model').property(assignment.sourceField!.name!).maybeWhereIterableNotNull(
           condition: shouldFilterNullInSource,
           isOnNullable: sourceNullable,
         );
@@ -149,7 +146,7 @@ class ValueAssignmentBuilder {
     final shouldRemoveNullsValue =
         sourceNullableValue && !targetNullableValue && (!(valueMapping?.hasWhenNullDefault() ?? false));
 
-    final sourceMapExpression = refer('model').property(assignment.sourceField!.name);
+    final sourceMapExpression = refer('model').property(assignment.sourceField!.name!);
 
     final defaultMapValueExpression = literalMap(
       {},
@@ -202,7 +199,7 @@ class ValueAssignmentBuilder {
     bool includeGenericTypes = false,
   }) {
     if (source.isAssignableTo(target)) {
-      final expression = convertMethodArgument ?? refer('model').property(assignment.sourceField!.displayName);
+      final expression = convertMethodArgument ?? assignment.sourceExpression;
 
       if(assignment.fieldMapping?.hasWhenNullDefault() ?? false) {
         return expression.ifNullThen(assignment.fieldMapping!.whenNullExpression!);

--- a/packages/auto_mappr/lib/src/builder/value_assignment_builder.dart
+++ b/packages/auto_mappr/lib/src/builder/value_assignment_builder.dart
@@ -70,7 +70,7 @@ class ValueAssignmentBuilder {
     final shouldFilterNullInSource = sourceIterableType.nullabilitySuffix == NullabilitySuffix.question &&
         targetIterableType.nullabilitySuffix != NullabilitySuffix.question;
 
-    final assignNestedObject = !targetIterableType.isPrimitiveType && (!targetIterableType.isSame(sourceIterableType));
+    final assignNestedObject = !targetIterableType.isPrimitiveType && (!targetIterableType.isAssignableTo(sourceIterableType));
 
     // When [sourceIterableType] is nullable and [targetIterableType] is not, remove null values.
     final sourceIterableExpression = refer('model').property(assignment.sourceField!.name).maybeWhereIterableNotNull(
@@ -201,7 +201,7 @@ class ValueAssignmentBuilder {
     Expression? convertMethodArgument,
     bool includeGenericTypes = false,
   }) {
-    if (source.isSame(target)) {
+    if (source.isAssignableTo(target)) {
       final expression = convertMethodArgument ?? refer('model').property(assignment.sourceField!.displayName);
 
       if(assignment.fieldMapping?.hasWhenNullDefault() ?? false) {

--- a/packages/auto_mappr/lib/src/builder/value_assignment_builder.dart
+++ b/packages/auto_mappr/lib/src/builder/value_assignment_builder.dart
@@ -88,7 +88,7 @@ class ValueAssignmentBuilder {
           isOnNullable: sourceNullable,
         );
 
-    final defaultIterableValueExpression = targetType.defaultIterableExpression();
+    final defaultIterableValueExpression = targetType.defaultIterableExpression(config: mapperConfig);
 
     if (assignNestedObject) {
       return sourceIterableExpression
@@ -99,9 +99,9 @@ class ValueAssignmentBuilder {
             {},
             [
               refer(
-                targetIterableType.getDisplayString(
+                targetIterableType.getDisplayStringWithLibraryAlias(
                   withNullability: true,
-                  // classType: assignment.typeMapping.target,
+                  config: mapperConfig,
                 ),
               )
             ],
@@ -163,8 +163,8 @@ class ValueAssignmentBuilder {
 
     final defaultMapValueExpression = literalMap(
       {},
-      refer(targetKeyType.getDisplayString(withNullability: true)),
-      refer(targetValueType.getDisplayString(withNullability: true)),
+      refer(targetKeyType.getDisplayStringWithLibraryAlias(withNullability: true, config: mapperConfig)),
+      refer(targetValueType.getDisplayStringWithLibraryAlias(withNullability: true, config: mapperConfig)),
     );
 
     final assignNestedObjectKey = !targetKeyType.isPrimitiveType && (targetKeyType != sourceKeyType);
@@ -180,6 +180,7 @@ class ValueAssignmentBuilder {
       valueIsNullable: shouldRemoveNullsValue,
       keyType: sourceKeyType,
       valueType: sourceValueType,
+      config: mapperConfig,
     )
         .maybeCall(
       'map',
@@ -190,8 +191,8 @@ class ValueAssignmentBuilder {
         _callMapForMap(assignment),
       ],
       typeArguments: [
-        refer(targetKeyType.getDisplayString(withNullability: true)),
-        refer(targetValueType.getDisplayString(withNullability: true)),
+        refer(targetKeyType.getDisplayStringWithLibraryAlias(withNullability: true, config: mapperConfig)),
+        refer(targetValueType.getDisplayStringWithLibraryAlias(withNullability: true, config: mapperConfig)),
       ],
     )
         // When [sourceNullable], use default value.
@@ -220,7 +221,10 @@ class ValueAssignmentBuilder {
     );
 
     if (nestedMapping == null) {
-      final targetTypeName = target.getDisplayString(withNullability: true);
+      final targetTypeName = target.getDisplayStringWithLibraryAlias(
+        withNullability: true,
+        config: mapperConfig,
+      );
       final sourceName = assignment.sourceField?.getDisplayString(withNullability: true);
 
       if (target.nullabilitySuffix == NullabilitySuffix.question) {
@@ -291,10 +295,12 @@ class ValueAssignmentBuilder {
           ? ConvertMethodBuilder.concreteNullableConvertMethodName(
               source: source,
               target: target,
+              config: mapperConfig,
             )
           : ConvertMethodBuilder.concreteConvertMethodName(
               source: source,
               target: target,
+              config: mapperConfig,
             ),
     );
 
@@ -309,8 +315,8 @@ class ValueAssignmentBuilder {
             {},
             includeGenericTypes
                 ? [
-                    refer(source.getDisplayString(withNullability: true)),
-                    refer(target.getDisplayString(withNullability: true))
+                    refer(source.getDisplayStringWithLibraryAlias(withNullability: true, config: mapperConfig)),
+                    refer(target.getDisplayStringWithLibraryAlias(withNullability: true, config: mapperConfig))
                   ]
                 : [],
           );

--- a/packages/auto_mappr/lib/src/extensions/dart_object_extension.dart
+++ b/packages/auto_mappr/lib/src/extensions/dart_object_extension.dart
@@ -1,7 +1,9 @@
 //ignore_for_file: no-object-declaration
 
 import 'package:analyzer/dart/constant/value.dart';
+import 'package:analyzer/dart/element/type.dart';
 import 'package:auto_mappr/src/extensions/executable_element_extension.dart';
+import 'package:auto_mappr/src/models/type_conversion.dart';
 import 'package:code_builder/code_builder.dart';
 import 'package:source_gen/source_gen.dart';
 
@@ -28,6 +30,24 @@ extension DartObjectExtension on DartObject {
     final output = _toSpec().accept(emitter);
 
     return CodeExpression(Code('$output'));
+  }
+
+  TypeConversion? toTypeConversion() {
+    final asParametrizedType = type as ParameterizedType?;
+
+    if (asParametrizedType?.typeArguments.length != 2) {
+      return null;
+    }
+
+    final source = asParametrizedType!.typeArguments.first;
+    final target = asParametrizedType.typeArguments.last;
+    final convert = getField('convert')!.toFunctionValue();
+
+    return TypeConversion(
+      source: source,
+      target: target,
+      convertExpression: refer(convert!.referCallString),
+    );
   }
 
   Spec _toSpec() {

--- a/packages/auto_mappr/lib/src/extensions/dart_object_extension.dart
+++ b/packages/auto_mappr/lib/src/extensions/dart_object_extension.dart
@@ -45,12 +45,12 @@ extension DartObjectExtension on DartObject {
       );
     }
 
-    final source = function.parameters.first.type;
-    final target = function.returnType;
+    final sourceType = function.parameters.first.type;
+    final targetType = function.returnType;
 
     return TypeConversion(
-      source: source,
-      target: target,
+      sourceType: sourceType,
+      targetType: targetType,
       convertExpression: refer(function.referCallString),
       field: getField('field')?.toStringValue(),
     );

--- a/packages/auto_mappr/lib/src/extensions/dart_object_extension.dart
+++ b/packages/auto_mappr/lib/src/extensions/dart_object_extension.dart
@@ -38,14 +38,14 @@ extension DartObjectExtension on DartObject {
       return null;
     }
 
-    if(function.parameters.length != 1) {
+    if(function.parameters.where((element) => element.isPositional).length != 1) {
       throw InvalidGenerationSourceError(
-        'TypeConverter function must have exactly one parameter.',
+        'TypeConverter function must have exactly one required parameter positional parameter.',
         element: function,
       );
     }
 
-    final sourceType = function.parameters.first.type;
+    final sourceType = function.parameters.firstWhere((element) => element.isPositional).type;
     final targetType = function.returnType;
 
     return TypeConversion(

--- a/packages/auto_mappr/lib/src/extensions/dart_type_extension.dart
+++ b/packages/auto_mappr/lib/src/extensions/dart_type_extension.dart
@@ -1,5 +1,7 @@
 import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart';
+import 'package:auto_mappr/src/extensions/element_extension.dart';
+import 'package:auto_mappr/src/models/auto_mappr_config.dart';
 import 'package:code_builder/code_builder.dart';
 
 extension DartTypeExtension on DartType {
@@ -41,44 +43,100 @@ extension DartTypeExtension on DartType {
 
     final isSameExceptNullability = isSameName && isSameLibrary;
 
-    if (withNullability) {
+    if (!withNullability) {
       return isSameExceptNullability;
     }
 
     // Nullability matches.
-    final thisNullability = nullabilitySuffix == NullabilitySuffix.star;
-    final otherNullability = other.nullabilitySuffix == NullabilitySuffix.star;
+    final thisNullability = nullabilitySuffix == NullabilitySuffix.question;
+    final otherNullability = other.nullabilitySuffix == NullabilitySuffix.question;
     final isSameNullability = thisNullability == otherNullability;
 
     return isSameExceptNullability && isSameNullability;
   }
 
-  Expression defaultIterableExpression() {
+  Expression defaultIterableExpression({
+    required AutoMapprConfig config,
+  }) {
     final itemType = (this as ParameterizedType).typeArguments.first;
 
-    if (isDartCoreList) {
-      return literalList([], refer(itemType.getDisplayString(withNullability: true)));
+    if (isDartCoreSet) {
+      return literalSet(
+        {},
+        refer(
+          itemType.getDisplayStringWithLibraryAlias(
+            config: config,
+            withNullability: true,
+          ),
+        ),
+      );
     }
 
-    // set
-    return literalSet({}, refer(itemType.getDisplayString(withNullability: true)));
+    return literalList(
+      [],
+      refer(
+        itemType.getDisplayStringWithLibraryAlias(
+          config: config,
+          withNullability: true,
+        ),
+      ),
+    );
   }
 
-  String toConvertMethodName({
-    required bool withNullability,
+  String getDisplayStringWithLibraryAlias({
+    required AutoMapprConfig config,
+    bool withNullability = false,
   }) {
-    final buffer = StringBuffer()..write(element!.name);
+    final alias = element!.getLibraryAlias(config: config);
+    final connectionString = alias.trim().isEmpty ? '' : '.';
+    final typeName = element!.name;
+    final buffer = StringBuffer('$alias$connectionString$typeName');
 
     if (this is ParameterizedType && (this as ParameterizedType).typeArguments.isNotEmpty) {
       final arguments = (this as ParameterizedType)
           .typeArguments
-          .map<String>((argument) => argument.toConvertMethodName(withNullability: withNullability))
+          .map<String>(
+            (argument) => argument.getDisplayStringWithLibraryAlias(
+              withNullability: withNullability,
+              config: config,
+            ),
+          )
+          .join(',');
+      buffer.write('<$arguments>');
+    }
+
+    // Nullability
+    if (withNullability && nullabilitySuffix == NullabilitySuffix.question) {
+      buffer.write('?');
+    }
+
+    return buffer.toString();
+  }
+
+  String toConvertMethodName({
+    required bool withNullability,
+    required AutoMapprConfig config,
+  }) {
+    final libraryAlias = element!.getLibraryAlias(config: config);
+    final connectionString = libraryAlias.trim().isEmpty ? '' : '_';
+    final typeName = element!.name;
+    final buffer = StringBuffer()..write('$libraryAlias$connectionString$typeName');
+
+    if (this is ParameterizedType && (this as ParameterizedType).typeArguments.isNotEmpty) {
+      final arguments = (this as ParameterizedType)
+          .typeArguments
+          .map<String>(
+            (argument) => argument.toConvertMethodName(
+              withNullability: withNullability,
+              config: config,
+            ),
+          )
           .join(r'$');
       buffer.write('\$$arguments');
     }
 
     // Nullability
-    if (withNullability && nullabilitySuffix == NullabilitySuffix.star) {
+    if (withNullability && nullabilitySuffix == NullabilitySuffix.question) {
       buffer.write('?');
     }
 

--- a/packages/auto_mappr/lib/src/extensions/element_extension.dart
+++ b/packages/auto_mappr/lib/src/extensions/element_extension.dart
@@ -1,0 +1,21 @@
+import 'package:analyzer/dart/element/element.dart';
+import 'package:auto_mappr/src/models/auto_mappr_config.dart';
+
+extension ElementExtension on Element {
+  String getLibraryAlias({
+    required AutoMapprConfig config,
+  }) {
+    var alias = '';
+
+    if (!(library?.isInSdk ?? false)) {
+      final libraryUri = source?.uri.toString();
+      final contains = config.libraryUriToAlias.containsKey(libraryUri);
+
+      if (contains) {
+        alias = config.libraryUriToAlias[libraryUri]!;
+      }
+    }
+
+    return alias;
+  }
+}

--- a/packages/auto_mappr/lib/src/extensions/expression_extension.dart
+++ b/packages/auto_mappr/lib/src/extensions/expression_extension.dart
@@ -1,4 +1,6 @@
 import 'package:analyzer/dart/element/type.dart';
+import 'package:auto_mappr/src/extensions/dart_type_extension.dart';
+import 'package:auto_mappr/src/models/auto_mappr_config.dart';
 import 'package:code_builder/code_builder.dart';
 
 extension ExpressionExtension on Expression {
@@ -81,6 +83,7 @@ extension ExpressionExtension on Expression {
     required bool valueIsNullable,
     required DartType keyType,
     required DartType valueType,
+    required AutoMapprConfig config,
   }) {
     if (!(keyIsNullable || valueIsNullable)) return this;
 
@@ -94,8 +97,8 @@ extension ExpressionExtension on Expression {
       ],
       {},
       [
-        refer(keyType.getDisplayString(withNullability: false)),
-        refer(valueType.getDisplayString(withNullability: false)),
+        refer(keyType.getDisplayStringWithLibraryAlias(config: config)),
+        refer(valueType.getDisplayStringWithLibraryAlias(config: config)),
       ],
     );
   }

--- a/packages/auto_mappr/lib/src/extensions/list_extension.dart
+++ b/packages/auto_mappr/lib/src/extensions/list_extension.dart
@@ -1,0 +1,16 @@
+extension ListExtension<T> on List<T> {
+  List<T> get duplicates {
+    final dup = <T>[];
+    final buffer = <T>[];
+
+    for (final x in this) {
+      if (buffer.contains(x)) {
+        dup.add(x);
+      } else {
+        buffer.add(x);
+      }
+    }
+
+    return dup;
+  }
+}

--- a/packages/auto_mappr/lib/src/generator/auto_mappr_generator.dart
+++ b/packages/auto_mappr/lib/src/generator/auto_mappr_generator.dart
@@ -29,10 +29,19 @@ class AutoMapprGenerator extends GeneratorForAnnotation<AutoMappr> {
     final mappersField = constant.getField('mappers')!;
     final mappersList = mappersField.toListValue()!;
 
+    final typesField = constant.getField('types')!;
+    final typesList = typesField.toListValue()!;
+    final typeConversions = typesList
+        .map((e) => e.toTypeConversion())
+        .whereNotNull()
+        .toList();
+
+
     final libraryUriToAlias = _getLibraryAliases(element: element);
 
     final tmpConfig = AutoMapprConfig(
       mappers: [],
+      typeConversions: typeConversions,
       availableMappingsMacroId: 'tmp',
       libraryUriToAlias: libraryUriToAlias,
     );
@@ -56,6 +65,7 @@ class AutoMapprGenerator extends GeneratorForAnnotation<AutoMappr> {
 
     final config = AutoMapprConfig(
       mappers: mappers,
+      typeConversions: typeConversions,
       availableMappingsMacroId: element.library.identifier,
       libraryUriToAlias: libraryUriToAlias,
     );
@@ -97,6 +107,7 @@ class AutoMapprGenerator extends GeneratorForAnnotation<AutoMappr> {
       final fields = mapper.getField('fields')?.toListValue();
       final whenSourceIsNull = mapper.getField('whenSourceIsNull')?.toCodeExpression();
       final constructor = mapper.getField('constructor')?.toStringValue();
+      final typeConverters = mapper.getField('types')?.toListValue();
 
       final fieldMappings = fields
           ?.map(
@@ -106,14 +117,17 @@ class AutoMapprGenerator extends GeneratorForAnnotation<AutoMappr> {
               from: fieldMapping.getField('from')!.toStringValue(),
               customExpression: fieldMapping.getField('custom')!.toCodeExpression(passModelArgument: true),
               whenNullExpression: fieldMapping.getField('whenNull')!.toCodeExpression(),
+              typeConversion: fieldMapping.getField('type')!.toTypeConversion(),
             ),
           )
           .toList();
+      final typeConversions = typeConverters?.map((e) => e.toTypeConversion()).whereNotNull().toList();
 
       return TypeMapping(
         source: sourceType,
         target: targetType,
         fieldMappings: fieldMappings,
+        typeConversions: typeConversions,
         whenSourceIsNullExpression: whenSourceIsNull,
         constructor: constructor,
       );

--- a/packages/auto_mappr/lib/src/generator/auto_mappr_generator.dart
+++ b/packages/auto_mappr/lib/src/generator/auto_mappr_generator.dart
@@ -114,6 +114,7 @@ class AutoMapprGenerator extends GeneratorForAnnotation<AutoMappr> {
             (fieldMapping) => FieldMapping(
               field: fieldMapping.getField('field')!.toStringValue()!,
               ignore: fieldMapping.getField('ignore')!.toBoolValue()!,
+              nullChecked: fieldMapping.getField('nullChecked')!.toBoolValue()!,
               from: fieldMapping.getField('from')!.toStringValue(),
               customExpression: fieldMapping.getField('custom')!.toCodeExpression(passModelArgument: true),
               whenNullExpression: fieldMapping.getField('whenNull')!.toCodeExpression(),

--- a/packages/auto_mappr/lib/src/models/auto_mappr_config.dart
+++ b/packages/auto_mappr/lib/src/models/auto_mappr_config.dart
@@ -1,10 +1,12 @@
 import 'package:analyzer/dart/element/type.dart';
 import 'package:auto_mappr/src/extensions/dart_type_extension.dart';
-import 'package:auto_mappr/src/models/type_mapping.dart';
+import 'package:auto_mappr/src/models/models.dart';
+import 'package:auto_mappr/src/models/type_conversion.dart';
 import 'package:collection/collection.dart';
 
 class AutoMapprConfig {
   final List<TypeMapping> mappers;
+  final List<TypeConversion> typeConversions;
   final String availableMappingsMacroId;
   final Map<String, String> libraryUriToAlias;
 
@@ -12,6 +14,7 @@ class AutoMapprConfig {
 
   const AutoMapprConfig({
     required this.mappers,
+    required this.typeConversions,
     required this.availableMappingsMacroId,
     required this.libraryUriToAlias,
   });
@@ -32,6 +35,14 @@ class AutoMapprConfig {
       for (final mapper in mappers) _getTypeMappingDocs(mapper),
       '/// {@endtemplate}'
     ];
+  }
+
+  bool hasTypeConversion(SourceAssignment assignment) {
+    return typeConversions.any((element) => element.matchesAssignment(assignment));
+  }
+
+  TypeConversion getTypeConversion(SourceAssignment assignment) {
+    return typeConversions.firstWhere((element) => element.matchesAssignment(assignment));
   }
 
   String _getTypeMappingDocs(TypeMapping typeMapping) {

--- a/packages/auto_mappr/lib/src/models/auto_mappr_config.dart
+++ b/packages/auto_mappr/lib/src/models/auto_mappr_config.dart
@@ -6,12 +6,14 @@ import 'package:collection/collection.dart';
 class AutoMapprConfig {
   final List<TypeMapping> mappers;
   final String availableMappingsMacroId;
+  final Map<String, String> libraryUriToAlias;
 
   String get availableMappingsMacroDocComment => '/// {@macro $availableMappingsMacroId}';
 
   const AutoMapprConfig({
     required this.mappers,
     required this.availableMappingsMacroId,
+    required this.libraryUriToAlias,
   });
 
   TypeMapping? findMapping({
@@ -36,6 +38,10 @@ class AutoMapprConfig {
     final trailingPart = typeMapping.hasWhenNullDefault() ? ' -- With default value.' : '.';
 
     // ignore: avoid-non-ascii-symbols, it is ok
-    return '/// - `${typeMapping.source}` → `${typeMapping.target}`$trailingPart';
+    return '/// - `${typeMapping.source.getDisplayStringWithLibraryAlias(
+      config: this,
+    )}` → `${typeMapping.target.getDisplayStringWithLibraryAlias(
+      config: this,
+    )}`$trailingPart';
   }
 }

--- a/packages/auto_mappr/lib/src/models/auto_mappr_config.dart
+++ b/packages/auto_mappr/lib/src/models/auto_mappr_config.dart
@@ -24,7 +24,7 @@ class AutoMapprConfig {
     required DartType target,
   }) {
     return mappers.firstWhereOrNull(
-      (mapper) => mapper.source.isSame(source) && mapper.target.isSame(target),
+      (mapper) => mapper.source.isAssignableTo(source) && mapper.target.isAssignableTo(target),
     );
   }
 

--- a/packages/auto_mappr/lib/src/models/field_mapping.dart
+++ b/packages/auto_mappr/lib/src/models/field_mapping.dart
@@ -44,7 +44,7 @@ class FieldMapping extends Equatable {
   }
 
   bool hasTypeConversion(SourceAssignment assignment) {
-    return typeConversion != null && typeConversion!.matches(assignment.sourceType, assignment.targetType);
+    return typeConversion != null && typeConversion!.matchesAssignment(assignment);
   }
 
   bool canBeApplied(SourceAssignment assignment) {

--- a/packages/auto_mappr/lib/src/models/field_mapping.dart
+++ b/packages/auto_mappr/lib/src/models/field_mapping.dart
@@ -7,6 +7,7 @@ import 'package:source_gen/source_gen.dart';
 class FieldMapping extends Equatable {
   final String field;
   final bool ignore;
+  final bool nullChecked;
   final String? from;
   final Expression? customExpression;
   final Expression? whenNullExpression;
@@ -16,6 +17,7 @@ class FieldMapping extends Equatable {
   List<Object?> get props => [
         field,
         ignore,
+        nullChecked,
         from,
         customExpression,
         whenNullExpression,
@@ -25,6 +27,7 @@ class FieldMapping extends Equatable {
   const FieldMapping({
     required this.field,
     required this.ignore,
+    required this.nullChecked,
     required this.from,
     required this.customExpression,
     required this.whenNullExpression,

--- a/packages/auto_mappr/lib/src/models/source_assignment.dart
+++ b/packages/auto_mappr/lib/src/models/source_assignment.dart
@@ -112,7 +112,7 @@ class SourceAssignment {
     if (targetType.isDartCoreSet) return literalSet({});
     if (targetType.isDartCoreMap) return literalMap({});
 
-    return literalNull;
+    return fieldMapping?.whenNullExpression ?? literalNull;
   }
 
   bool _isCoreIterable(DartType type) {

--- a/packages/auto_mappr/lib/src/models/source_assignment.dart
+++ b/packages/auto_mappr/lib/src/models/source_assignment.dart
@@ -4,6 +4,7 @@ import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:auto_mappr/src/extensions/dart_type_extension.dart';
 import 'package:auto_mappr/src/models/models.dart';
+import 'package:auto_mappr/src/models/type_conversion.dart';
 import 'package:code_builder/code_builder.dart';
 
 class ConstructorAssignment {
@@ -54,6 +55,14 @@ class SourceAssignment {
     this.targetConstructorParam,
     this.fieldMapping,
   });
+
+  bool hasTypeConversion() {
+    return typeMapping.typeConversions?.any((element) => element.matchesAssignment(this)) ?? false;
+  }
+
+  TypeConversion getTypeConversion() {
+    return typeMapping.typeConversions!.firstWhere((element) => element.matchesAssignment(this));
+  }
 
   bool shouldAssignIterable() {
     // The source can be mapped to the target, if the source is mappable object and the target is an iterable.

--- a/packages/auto_mappr/lib/src/models/source_assignment.dart
+++ b/packages/auto_mappr/lib/src/models/source_assignment.dart
@@ -34,6 +34,8 @@ class SourceAssignment {
   /// Like UserDto to User.
   final TypeMapping typeMapping;
 
+  final AutoMapprConfig config;
+
   bool get shouldBeIgnored => fieldMapping?.ignore ?? false;
 
   DartType? get sourceType => sourceField?.returnType;
@@ -48,6 +50,7 @@ class SourceAssignment {
     required this.sourceField,
     required this.targetField,
     required this.typeMapping,
+    required this.config,
     this.targetConstructorParam,
     this.fieldMapping,
   });
@@ -66,8 +69,8 @@ class SourceAssignment {
 
   @override
   String toString() {
-    final sourceTypeName = sourceType?.getDisplayString(withNullability: true);
-    final targetTypeName = targetType.getDisplayString(withNullability: true);
+    final sourceTypeName = sourceType?.getDisplayStringWithLibraryAlias(withNullability: true, config: config);
+    final targetTypeName = targetType.getDisplayStringWithLibraryAlias(withNullability: true, config: config);
 
     return '$sourceTypeName $sourceName -> $targetTypeName $targetName';
   }

--- a/packages/auto_mappr/lib/src/models/source_assignment.dart
+++ b/packages/auto_mappr/lib/src/models/source_assignment.dart
@@ -20,7 +20,8 @@ class ConstructorAssignment {
 }
 
 class SourceAssignment {
-  final PropertyAccessorElement? sourceField;
+  final Element? sourceField;
+  final DartType? sourceType;
 
   final ConstructorAssignment? targetConstructorParam;
   final PropertyAccessorElement? targetField;
@@ -39,16 +40,38 @@ class SourceAssignment {
 
   bool get shouldBeIgnored => fieldMapping?.ignore ?? false;
 
-  DartType? get sourceType => sourceField?.returnType;
-
   String? get sourceName => sourceField?.displayName;
+
+  PropertyAccessorElement? get sourceFieldAccessor => sourceField is PropertyAccessorElement? sourceField as PropertyAccessorElement? : null;
+
+  bool get sourceIsStatic => sourceFieldAccessor?.isStatic ?? false;
+
+  Expression get sourceExpression {
+    final expression = refer(sourceIsStatic ? '${sourceField?.enclosingElement?.name}' : 'model');
+
+    if (sourceFieldAccessor != null) {
+      return expression.property(sourceName!);
+    }
+
+    return expression;
+  }
 
   DartType get targetType => targetConstructorParam?.param.type ?? targetField!.returnType;
 
   String get targetName => targetConstructorParam?.param.displayName ?? targetField!.displayName;
 
   SourceAssignment({
+    required PropertyAccessorElement? this.sourceField,
+    required this.targetField,
+    required this.typeMapping,
+    required this.config,
+    this.targetConstructorParam,
+    this.fieldMapping,
+  }) : sourceType = sourceField?.returnType;
+
+  SourceAssignment.from({
     required this.sourceField,
+    required this.sourceType,
     required this.targetField,
     required this.typeMapping,
     required this.config,

--- a/packages/auto_mappr/lib/src/models/type_conversion.dart
+++ b/packages/auto_mappr/lib/src/models/type_conversion.dart
@@ -40,7 +40,7 @@ class TypeConversion extends Equatable {
     final targetNullable = targetType.nullabilitySuffix != NullabilitySuffix.none;
     final whenNullExpression = assignment.fieldMapping?.whenNullExpression;
 
-    var sourceExpression = refer('model').property(assignment.sourceName!);
+    var sourceExpression = assignment.sourceExpression;
     if(assignmentSourceNullChecked) {
       sourceExpression = sourceExpression.nullChecked;
     }

--- a/packages/auto_mappr/lib/src/models/type_conversion.dart
+++ b/packages/auto_mappr/lib/src/models/type_conversion.dart
@@ -4,19 +4,20 @@ import 'package:auto_mappr/src/extensions/dart_type_extension.dart';
 import 'package:auto_mappr/src/models/source_assignment.dart';
 import 'package:code_builder/code_builder.dart';
 import 'package:equatable/equatable.dart';
+import 'package:source_gen/source_gen.dart';
 
 class TypeConversion extends Equatable {
-  final DartType source;
-  final DartType target;
+  final DartType sourceType;
+  final DartType targetType;
   final Expression convertExpression;
   final String? field;
 
   @override
-  List<Object?> get props => [source, target, convertExpression, field];
+  List<Object?> get props => [sourceType, targetType, convertExpression, field];
 
   const TypeConversion({
-    required this.source,
-    required this.target,
+    required this.sourceType,
+    required this.targetType,
     required this.convertExpression,
     required this.field,
   });
@@ -24,29 +25,42 @@ class TypeConversion extends Equatable {
   /// Wether this type conversion applies to the the given [SourceAssignment].
   bool matchesAssignment(SourceAssignment assignment) {
     final typeMatches = assignment.sourceType != null &&
-        assignment.sourceType!.isSame(source) &&
-        assignment.targetType.isSame(target);
+        assignment.sourceType!.isSame(sourceType, allowSubtypes: true) &&
+        assignment.targetType.isSame(targetType);
     final nameMatches = field == null || assignment.sourceName == field;
 
     return typeMatches && nameMatches;
   }
 
   Expression apply(SourceAssignment assignment) {
-    if (assignment.sourceType?.nullabilitySuffix == NullabilitySuffix.question &&
-        target.nullabilitySuffix == NullabilitySuffix.none) {
-      return refer('model')
-          .property(assignment.sourceName!)
-          .notEqualTo(literalNull)
-          .conditional(
-            convertExpression.call([
-              refer('model').property(assignment.sourceName!).nullChecked,
-            ]),
-            literalNull,
-          );
+    final assignmentSourceNullable = assignment.sourceType?.nullabilitySuffix != NullabilitySuffix.none;
+    final assignmentTargetNullable = assignment.targetType.nullabilitySuffix != NullabilitySuffix.none;
+    final sourceNullable = sourceType.nullabilitySuffix != NullabilitySuffix.none;
+    final targetNullable = targetType.nullabilitySuffix != NullabilitySuffix.none;
+    final whenNullExpression = assignment.fieldMapping?.whenNullExpression;
+
+    final sourceExpression = refer('model').property(assignment.sourceName!);
+
+    if((assignmentSourceNullable || targetNullable) && !assignmentTargetNullable && whenNullExpression == null) {
+      throw InvalidGenerationSourceError(
+        'Cannot convert nullable source type to non-nullable target type requirement without a default value.',
+        element: assignment.sourceField,
+      );
     }
 
-    return convertExpression.call([
-      refer('model').property(assignment.sourceName!),
-    ]);
+    if(assignmentSourceNullable && !sourceNullable) {
+      return sourceExpression.notEqualTo(literalNull).conditional(
+        convertExpression.call([sourceExpression.nullChecked]),
+        whenNullExpression ?? literalNull,
+      );
+    } else {
+      final expression = convertExpression.call([sourceExpression]);
+
+      if(targetNullable) {
+        return expression.ifNullThen(whenNullExpression!);
+      }
+
+      return expression;
+    }
   }
 }

--- a/packages/auto_mappr/lib/src/models/type_conversion.dart
+++ b/packages/auto_mappr/lib/src/models/type_conversion.dart
@@ -33,17 +33,21 @@ class TypeConversion extends Equatable {
   }
 
   Expression apply(SourceAssignment assignment) {
-    final assignmentSourceNullable = assignment.sourceType?.nullabilitySuffix != NullabilitySuffix.none;
+    final assignmentSourceNullChecked = assignment.fieldMapping?.nullChecked ?? false;
+    final assignmentSourceNullable = assignment.sourceType?.nullabilitySuffix != NullabilitySuffix.none && !assignmentSourceNullChecked;
     final assignmentTargetNullable = assignment.targetType.nullabilitySuffix != NullabilitySuffix.none;
     final sourceNullable = sourceType.nullabilitySuffix != NullabilitySuffix.none;
     final targetNullable = targetType.nullabilitySuffix != NullabilitySuffix.none;
     final whenNullExpression = assignment.fieldMapping?.whenNullExpression;
 
-    final sourceExpression = refer('model').property(assignment.sourceName!);
+    var sourceExpression = refer('model').property(assignment.sourceName!);
+    if(assignmentSourceNullChecked) {
+      sourceExpression = sourceExpression.nullChecked;
+    }
 
-    if((assignmentSourceNullable || targetNullable) && !assignmentTargetNullable && whenNullExpression == null) {
+    if((assignmentSourceNullable || targetNullable) && !assignmentTargetNullable && whenNullExpression == null && !assignmentSourceNullChecked) {
       throw InvalidGenerationSourceError(
-        'Cannot convert nullable source type to non-nullable target type requirement without a default value.',
+        'Cannot convert nullable source type to non-nullable target type without a default value.',
         element: assignment.sourceField,
       );
     }

--- a/packages/auto_mappr/lib/src/models/type_conversion.dart
+++ b/packages/auto_mappr/lib/src/models/type_conversion.dart
@@ -9,34 +9,40 @@ class TypeConversion extends Equatable {
   final DartType source;
   final DartType target;
   final Expression convertExpression;
+  final String? field;
 
   @override
-  List<Object?> get props => [source, target, convertExpression];
+  List<Object?> get props => [source, target, convertExpression, field];
 
   const TypeConversion({
     required this.source,
     required this.target,
     required this.convertExpression,
+    required this.field,
   });
 
-  /// Wether this type conversion applies to the source and target types.
-  bool matches(DartType? source, DartType? target) {
-    return source != null && target != null && source.isSame(this.source) && target.isSame(this.target);
-  }
-
-  /// Wether this type conversion applies to the source and target types of the given assignment.
+  /// Wether this type conversion applies to the the given [SourceAssignment].
   bool matchesAssignment(SourceAssignment assignment) {
-    return matches(assignment.sourceType, assignment.targetType);
+    final typeMatches = assignment.sourceType != null &&
+        assignment.sourceType!.isSame(source) &&
+        assignment.targetType.isSame(target);
+    final nameMatches = field == null || assignment.sourceName == field;
+
+    return typeMatches && nameMatches;
   }
 
   Expression apply(SourceAssignment assignment) {
-    if(assignment.sourceType?.nullabilitySuffix == NullabilitySuffix.question && target.nullabilitySuffix == NullabilitySuffix.none) {
-      return refer('model').property(assignment.sourceName!).notEqualTo(literalNull).conditional(
-        convertExpression.call([
-          refer('model').property(assignment.sourceName!).nullChecked,
-        ]),
-        literalNull,
-      );
+    if (assignment.sourceType?.nullabilitySuffix == NullabilitySuffix.question &&
+        target.nullabilitySuffix == NullabilitySuffix.none) {
+      return refer('model')
+          .property(assignment.sourceName!)
+          .notEqualTo(literalNull)
+          .conditional(
+            convertExpression.call([
+              refer('model').property(assignment.sourceName!).nullChecked,
+            ]),
+            literalNull,
+          );
     }
 
     return convertExpression.call([

--- a/packages/auto_mappr/lib/src/models/type_conversion.dart
+++ b/packages/auto_mappr/lib/src/models/type_conversion.dart
@@ -25,8 +25,8 @@ class TypeConversion extends Equatable {
   /// Wether this type conversion applies to the the given [SourceAssignment].
   bool matchesAssignment(SourceAssignment assignment) {
     final typeMatches = assignment.sourceType != null &&
-        assignment.sourceType!.isSame(sourceType, allowSubtypes: true) &&
-        assignment.targetType.isSame(targetType);
+        assignment.sourceType!.isAssignableTo(sourceType) &&
+        assignment.targetType.isAssignableTo(targetType);
     final nameMatches = field == null || assignment.sourceName == field;
 
     return typeMatches && nameMatches;

--- a/packages/auto_mappr/lib/src/models/type_conversion.dart
+++ b/packages/auto_mappr/lib/src/models/type_conversion.dart
@@ -1,0 +1,46 @@
+import 'package:analyzer/dart/element/nullability_suffix.dart';
+import 'package:analyzer/dart/element/type.dart';
+import 'package:auto_mappr/src/extensions/dart_type_extension.dart';
+import 'package:auto_mappr/src/models/source_assignment.dart';
+import 'package:code_builder/code_builder.dart';
+import 'package:equatable/equatable.dart';
+
+class TypeConversion extends Equatable {
+  final DartType source;
+  final DartType target;
+  final Expression convertExpression;
+
+  @override
+  List<Object?> get props => [source, target, convertExpression];
+
+  const TypeConversion({
+    required this.source,
+    required this.target,
+    required this.convertExpression,
+  });
+
+  /// Wether this type conversion applies to the source and target types.
+  bool matches(DartType? source, DartType? target) {
+    return source != null && target != null && source.isSame(this.source) && target.isSame(this.target);
+  }
+
+  /// Wether this type conversion applies to the source and target types of the given assignment.
+  bool matchesAssignment(SourceAssignment assignment) {
+    return matches(assignment.sourceType, assignment.targetType);
+  }
+
+  Expression apply(SourceAssignment assignment) {
+    if(assignment.sourceType?.nullabilitySuffix == NullabilitySuffix.question && target.nullabilitySuffix == NullabilitySuffix.none) {
+      return refer('model').property(assignment.sourceName!).notEqualTo(literalNull).conditional(
+        convertExpression.call([
+          refer('model').property(assignment.sourceName!).nullChecked,
+        ]),
+        literalNull,
+      );
+    }
+
+    return convertExpression.call([
+      refer('model').property(assignment.sourceName!),
+    ]);
+  }
+}

--- a/packages/auto_mappr/lib/src/models/type_mapping.dart
+++ b/packages/auto_mappr/lib/src/models/type_mapping.dart
@@ -3,6 +3,8 @@
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:auto_mappr/src/builder/convert_method_builder.dart';
+import 'package:auto_mappr/src/extensions/dart_type_extension.dart';
+import 'package:auto_mappr/src/models/auto_mappr_config.dart';
 import 'package:auto_mappr/src/models/field_mapping.dart';
 import 'package:code_builder/code_builder.dart';
 import 'package:collection/collection.dart';
@@ -14,16 +16,6 @@ class TypeMapping extends Equatable {
   final List<FieldMapping>? fieldMappings;
   final Expression? whenSourceIsNullExpression;
   final String? constructor;
-
-  String get mappingMethodName => ConvertMethodBuilder.concreteConvertMethodName(
-        source: source,
-        target: target,
-      );
-
-  String get nullableMappingMethodName => ConvertMethodBuilder.concreteNullableConvertMethodName(
-        source: source,
-        target: target,
-      );
 
   bool get isEnumMapping => source.element is EnumElement || target.element is EnumElement;
 
@@ -46,13 +38,27 @@ class TypeMapping extends Equatable {
     this.constructor,
   });
 
+  String mappingMethodName({
+    required AutoMapprConfig config,
+  }) =>
+      ConvertMethodBuilder.concreteConvertMethodName(
+        source: source,
+        target: target,
+        config: config,
+      );
+
+  String nullableMappingMethodName({
+    required AutoMapprConfig config,
+  }) =>
+      ConvertMethodBuilder.concreteNullableConvertMethodName(
+        source: source,
+        target: target,
+        config: config,
+      );
+
   bool hasWhenNullDefault() {
     return whenSourceIsNullExpression != null;
   }
-
-  String sourceName({bool withNullability = false}) => source.getDisplayString(withNullability: withNullability);
-
-  String targetName({bool withNullability = false}) => target.getDisplayString(withNullability: withNullability);
 
   bool hasFieldMapping(String field) => fieldMappings?.any((x) => x.field == field) ?? false;
 
@@ -66,5 +72,16 @@ class TypeMapping extends Equatable {
   String toString() {
     // ignore: avoid-non-ascii-symbols, it is ok
     return '$source → $target';
+  }
+
+  String toStringWithLibraryAlias({
+    required AutoMapprConfig config,
+  }) {
+    // ignore: avoid-non-ascii-symbols, it is ok
+    return '${source.getDisplayStringWithLibraryAlias(
+      config: config,
+    )} → ${target.getDisplayStringWithLibraryAlias(
+      config: config,
+    )}';
   }
 }

--- a/packages/auto_mappr/lib/src/models/type_mapping.dart
+++ b/packages/auto_mappr/lib/src/models/type_mapping.dart
@@ -6,6 +6,7 @@ import 'package:auto_mappr/src/builder/convert_method_builder.dart';
 import 'package:auto_mappr/src/extensions/dart_type_extension.dart';
 import 'package:auto_mappr/src/models/auto_mappr_config.dart';
 import 'package:auto_mappr/src/models/field_mapping.dart';
+import 'package:auto_mappr/src/models/type_conversion.dart';
 import 'package:code_builder/code_builder.dart';
 import 'package:collection/collection.dart';
 import 'package:equatable/equatable.dart';
@@ -14,6 +15,7 @@ class TypeMapping extends Equatable {
   final InterfaceType source;
   final InterfaceType target;
   final List<FieldMapping>? fieldMappings;
+  final List<TypeConversion>? typeConversions;
   final Expression? whenSourceIsNullExpression;
   final String? constructor;
 
@@ -25,6 +27,7 @@ class TypeMapping extends Equatable {
       source,
       target,
       fieldMappings,
+      typeConversions,
       whenSourceIsNullExpression,
       constructor,
     ];
@@ -33,9 +36,10 @@ class TypeMapping extends Equatable {
   const TypeMapping({
     required this.source,
     required this.target,
-    this.fieldMappings,
-    this.whenSourceIsNullExpression,
-    this.constructor,
+    required this.fieldMappings,
+    required this.typeConversions,
+    required this.whenSourceIsNullExpression,
+    required this.constructor,
   });
 
   String mappingMethodName({

--- a/packages/auto_mappr/test/builder/convert_method_builder_test.dart
+++ b/packages/auto_mappr/test/builder/convert_method_builder_test.dart
@@ -12,6 +12,7 @@ void main() {
         const AutoMapprConfig(
           mappers: [],
           availableMappingsMacroId: 'test',
+          libraryUriToAlias: {},
         ),
       ).buildConvertMethod();
 
@@ -37,6 +38,7 @@ void main() {
         const AutoMapprConfig(
           mappers: [],
           availableMappingsMacroId: 'test',
+          libraryUriToAlias: {},
         ),
       ).buildTryConvertMethod();
 
@@ -62,6 +64,7 @@ void main() {
         const AutoMapprConfig(
           mappers: [],
           availableMappingsMacroId: 'test',
+          libraryUriToAlias: {},
         ),
       ).buildInternalConvertMethod();
 
@@ -87,6 +90,7 @@ void main() {
         const AutoMapprConfig(
           mappers: [],
           availableMappingsMacroId: 'test',
+          libraryUriToAlias: {},
         ),
       ).buildTypeOfHelperMethod();
 

--- a/packages/auto_mappr/test/builder/convert_method_builder_test.dart
+++ b/packages/auto_mappr/test/builder/convert_method_builder_test.dart
@@ -5,16 +5,17 @@ import 'package:code_builder/code_builder.dart';
 import 'package:test/test.dart';
 
 void main() {
+  const testConfig = AutoMapprConfig(
+    mappers: [],
+    typeConversions: [],
+    availableMappingsMacroId: 'test',
+    libraryUriToAlias: {},
+  );
+
   test(
     'buildConvertMethod has the correct interface',
     () {
-      final result = ConvertMethodBuilder(
-        const AutoMapprConfig(
-          mappers: [],
-          availableMappingsMacroId: 'test',
-          libraryUriToAlias: {},
-        ),
-      ).buildConvertMethod();
+      final result = ConvertMethodBuilder(testConfig).buildConvertMethod();
 
       expect(result, isA<Method>());
       expect(result.name, 'convert');
@@ -34,13 +35,7 @@ void main() {
   test(
     'buildTryConvertMethod has the correct interface',
     () {
-      final result = ConvertMethodBuilder(
-        const AutoMapprConfig(
-          mappers: [],
-          availableMappingsMacroId: 'test',
-          libraryUriToAlias: {},
-        ),
-      ).buildTryConvertMethod();
+      final result = ConvertMethodBuilder(testConfig).buildTryConvertMethod();
 
       expect(result, isA<Method>());
       expect(result.name, 'tryConvert');
@@ -60,13 +55,7 @@ void main() {
   test(
     'buildInternalConvertMethod has the correct interface',
     () {
-      final result = ConvertMethodBuilder(
-        const AutoMapprConfig(
-          mappers: [],
-          availableMappingsMacroId: 'test',
-          libraryUriToAlias: {},
-        ),
-      ).buildInternalConvertMethod();
+      final result = ConvertMethodBuilder(testConfig).buildInternalConvertMethod();
 
       expect(result, isA<Method>());
       expect(result.name, '_convert');
@@ -86,13 +75,7 @@ void main() {
   test(
     'buildTypeOfHelperMethod has the correct interface',
     () {
-      final result = ConvertMethodBuilder(
-        const AutoMapprConfig(
-          mappers: [],
-          availableMappingsMacroId: 'test',
-          libraryUriToAlias: {},
-        ),
-      ).buildTypeOfHelperMethod();
+      final result = ConvertMethodBuilder(testConfig).buildTypeOfHelperMethod();
 
       expect(result, isA<Method>());
       expect(result.name, '_typeOf');

--- a/packages/auto_mappr/test/integration/fixture/import_alias.dart
+++ b/packages/auto_mappr/test/integration/fixture/import_alias.dart
@@ -1,0 +1,80 @@
+import 'package:auto_mappr_annotation/auto_mappr_annotation.dart';
+import 'package:equatable/equatable.dart';
+import 'import_alias_1.dart' as a1;
+import 'import_alias_2.dart' as a2;
+
+part 'import_alias.g.dart';
+
+@AutoMappr([
+  MapType<UserDto, User>(),
+  MapType<UserDto, a1.User>(),
+  MapType<UserDto, a2.User>(),
+  MapType<a1.UserDto, User>(),
+  MapType<a1.UserDto, a1.User>(),
+  MapType<a1.UserDto, a2.User>(),
+  MapType<a2.UserDto, User>(),
+  MapType<a2.UserDto, a1.User>(),
+  MapType<a2.UserDto, a2.User>(),
+  // generics
+  MapType<Holder<a1.UserDto, a2.UserDto>, a2.Holder<a1.User, a2.User>>(),
+  // iterable
+  MapType<ListHolder<UserDto>, ListHolder<a1.User>>(),
+  MapType<MapHolder<UserDto>, MapHolder<a2.User>>(),
+])
+class Mappr extends $Mappr {}
+
+class UserDto {
+  final String name;
+  final int age;
+
+  const UserDto({
+    required this.name,
+    required this.age,
+  });
+}
+
+class User with EquatableMixin {
+  final String name;
+  final int age;
+
+  @override
+  List<Object?> get props => [name, age];
+
+  const User({
+    required this.name,
+    required this.age,
+  });
+}
+
+class Holder<A, B> extends Equatable {
+  final A first;
+  final B second;
+
+  @override
+  List<Object?> get props => [first, second];
+
+  const Holder({
+    required this.first,
+    required this.second,
+  });
+}
+
+// iterables
+
+class ListHolder<T> with EquatableMixin {
+  final List<T> list;
+
+  @override
+  List<Object?> get props => [list];
+
+  const ListHolder(this.list);
+}
+
+class MapHolder<T> with EquatableMixin {
+  final Map<String, T> map;
+
+  @override
+  List<Object?> get props => [map];
+
+  const MapHolder(this.map);
+}

--- a/packages/auto_mappr/test/integration/fixture/import_alias_1.dart
+++ b/packages/auto_mappr/test/integration/fixture/import_alias_1.dart
@@ -1,0 +1,37 @@
+import 'package:equatable/equatable.dart';
+
+class UserDto {
+  final String name;
+  final int age;
+
+  const UserDto({
+    required this.name,
+    required this.age,
+  });
+}
+
+class User with EquatableMixin {
+  final String name;
+  final int age;
+
+  @override
+  List<Object?> get props => [name, age];
+
+  const User({
+    required this.name,
+    required this.age,
+  });
+}
+
+class Holder<A, B> extends Equatable {
+  final A first;
+  final B second;
+
+  @override
+  List<Object?> get props => [first, second];
+
+  const Holder({
+    required this.first,
+    required this.second,
+  });
+}

--- a/packages/auto_mappr/test/integration/fixture/import_alias_2.dart
+++ b/packages/auto_mappr/test/integration/fixture/import_alias_2.dart
@@ -1,0 +1,37 @@
+import 'package:equatable/equatable.dart';
+
+class UserDto {
+  final String name;
+  final int age;
+
+  const UserDto({
+    required this.name,
+    required this.age,
+  });
+}
+
+class User with EquatableMixin {
+  final String name;
+  final int age;
+
+  @override
+  List<Object?> get props => [name, age];
+
+  const User({
+    required this.name,
+    required this.age,
+  });
+}
+
+class Holder<A, B> extends Equatable {
+  final A first;
+  final B second;
+
+  @override
+  List<Object?> get props => [first, second];
+
+  const Holder({
+    required this.first,
+    required this.second,
+  });
+}

--- a/packages/auto_mappr/test/integration/fixture/type_converter.dart
+++ b/packages/auto_mappr/test/integration/fixture/type_converter.dart
@@ -46,8 +46,6 @@ abstract class ValueId<T> extends Equatable {
   const ValueId(this.value);
 
   static T toValue<T>(ValueId<T> id) => id.value;
-
-  static String toValueString(ValueId<String> id) => id.value;
 }
 
 class UserId extends ValueId<String> {
@@ -104,8 +102,8 @@ class UserDto {
     UserId.new,
     AccountId.new,
     // This doesn't work currently, maybe analyzer bug?
-    ValueId.toValue<String>,
-    ValueId.toValueString,
+    // ValueId.toValue<String>,
+    Mappr.valueIdToString,
   ],
 )
 class Mappr extends $Mappr {
@@ -129,4 +127,6 @@ class Mappr extends $Mappr {
   static DateTime parseISO8601(String input) {
     return DateTime.tryParse(input) ?? DateTime(1970);
   }
+
+  static String valueIdToString(ValueId<String> id) => id.value;
 }

--- a/packages/auto_mappr/test/integration/fixture/type_converter.dart
+++ b/packages/auto_mappr/test/integration/fixture/type_converter.dart
@@ -1,0 +1,124 @@
+import 'package:auto_mappr_annotation/auto_mappr_annotation.dart';
+import 'package:equatable/equatable.dart';
+
+part 'type_converter.g.dart';
+
+class DateDomain {
+  final DateTime? dateTimeA;
+  final DateTime? dateTimeB;
+  final DateTime? dateTimeC;
+
+  DateDomain({
+    required this.dateTimeA,
+    required this.dateTimeB,
+    required this.dateTimeC,
+  });
+}
+
+class DateDto {
+  final String dateTimeA;
+  final String dateTimeB;
+  final String dateTimeC;
+
+  DateDto({
+    required this.dateTimeA,
+    required this.dateTimeB,
+    required this.dateTimeC,
+  });
+}
+
+class DateDto2 {
+  final String dateTimeA;
+  final String dateTimeB;
+
+  DateDto2({
+    required this.dateTimeA,
+    required this.dateTimeB,
+  });
+}
+
+class UserId extends Equatable {
+  final String value;
+
+  @override
+  List<Object?> get props => [value];
+
+  const UserId(this.value);
+}
+
+class AccountId extends Equatable {
+  final String value;
+
+  @override
+  List<Object?> get props => [value];
+
+  const AccountId(this.value);
+}
+
+class User {
+  final UserId? id;
+  final AccountId? accountId;
+
+  User(this.id, this.accountId);
+}
+
+class UserDto {
+  final String? id;
+  final String? accountId;
+
+  UserDto(this.id, this.accountId);
+}
+
+
+@AutoMappr(
+  [
+    MapType<DateDto, DateDomain>(
+      fields: [
+        Field(
+          'dateTimeA',
+          type: TypeConverter<String, DateTime>(Mappr.tryParseFirstOfDecemberInYear),
+        ),
+      ],
+      types: [
+        TypeConverter<String, DateTime>(Mappr.parseSecondOfDecemberInYear),
+      ],
+    ),
+    MapType<DateDto2, DateDomain>(),
+    MapType<UserDto, User>(
+      fields: [
+        Field('id', type: TypeConverter<String, UserId>(UserId.new)),
+        Field('accountId', type: TypeConverter<String, AccountId>(AccountId.new)),
+      ],
+    ),
+  ],
+  types: [
+    TypeConverter<String, DateTime>(Mappr.parseISO8601),
+  ],
+)
+class Mappr extends $Mappr {
+  /// Expects a year as input and returns the first of december in that year.
+  ///
+  /// Falls back to first of december in 1970 if parsing fails.
+  static DateTime tryParseFirstOfDecemberInYear(String input) {
+    return int.tryParse(input)?.let((v) => DateTime(v, 12)) ?? DateTime(1970, 12);
+  }
+
+  /// Expects a year as input and returns the second of december in that year.
+  ///
+  /// Falls back to second of december in 1970 if parsing fails.
+  static DateTime parseSecondOfDecemberInYear(String input) {
+    return int.tryParse(input)?.let((v) => DateTime(v, 12, 2)) ?? DateTime(1970, 12, 2);
+  }
+
+  /// Expects a ISO8601 formatted string as input and returns a DateTime.
+  ///
+  /// Falls back to 1970 if parsing fails.
+  static DateTime parseISO8601(String input) {
+    return DateTime.tryParse(input) ?? DateTime(1970);
+  }
+}
+
+extension <T> on T {
+  @pragma('vm:prefer-inline')
+  R let<R>(R Function(T v) block) => block(this);
+}

--- a/packages/auto_mappr/test/integration/fixture/type_converter.dart
+++ b/packages/auto_mappr/test/integration/fixture/type_converter.dart
@@ -69,30 +69,29 @@ class UserDto {
   UserDto(this.id, this.accountId);
 }
 
-
 @AutoMappr(
   [
     MapType<DateDto, DateDomain>(
       fields: [
         Field(
           'dateTimeA',
-          type: TypeConverter<String, DateTime>(Mappr.tryParseFirstOfDecemberInYear),
+          type: Mappr.tryParseFirstOfDecemberInYear,
         ),
       ],
       types: [
-        TypeConverter<String, DateTime>(Mappr.parseSecondOfDecemberInYear),
+        Mappr.parseSecondOfDecemberInYear,
       ],
     ),
     MapType<DateDto2, DateDomain>(),
     MapType<UserDto, User>(
       fields: [
-        Field('id', type: TypeConverter<String, UserId>(UserId.new)),
-        Field('accountId', type: TypeConverter<String, AccountId>(AccountId.new)),
+        Field('id', type: UserId.new),
       ],
     ),
   ],
   types: [
-    TypeConverter<String, DateTime>(Mappr.parseISO8601),
+    Mappr.parseISO8601,
+    TypeConverter(AccountId.new, field: 'accountId'),
   ],
 )
 class Mappr extends $Mappr {
@@ -100,14 +99,16 @@ class Mappr extends $Mappr {
   ///
   /// Falls back to first of december in 1970 if parsing fails.
   static DateTime tryParseFirstOfDecemberInYear(String input) {
-    return int.tryParse(input)?.let((v) => DateTime(v, 12)) ?? DateTime(1970, 12);
+    return int.tryParse(input)?.let((v) => DateTime(v, 12)) ??
+        DateTime(1970, 12);
   }
 
   /// Expects a year as input and returns the second of december in that year.
   ///
   /// Falls back to second of december in 1970 if parsing fails.
   static DateTime parseSecondOfDecemberInYear(String input) {
-    return int.tryParse(input)?.let((v) => DateTime(v, 12, 2)) ?? DateTime(1970, 12, 2);
+    return int.tryParse(input)?.let((v) => DateTime(v, 12, 2)) ??
+        DateTime(1970, 12, 2);
   }
 
   /// Expects a ISO8601 formatted string as input and returns a DateTime.
@@ -118,7 +119,7 @@ class Mappr extends $Mappr {
   }
 }
 
-extension <T> on T {
+extension<T> on T {
   @pragma('vm:prefer-inline')
   R let<R>(R Function(T v) block) => block(this);
 }

--- a/packages/auto_mappr/test/integration/import_alias_test.dart
+++ b/packages/auto_mappr/test/integration/import_alias_test.dart
@@ -1,0 +1,168 @@
+import 'package:test/test.dart';
+
+import 'fixture/import_alias.dart' as fixture;
+import 'fixture/import_alias_1.dart' as fixture_a1;
+import 'fixture/import_alias_2.dart' as fixture_a2;
+
+void main() {
+  late final fixture.Mappr mappr;
+
+  setUpAll(() {
+    mappr = fixture.Mappr();
+  });
+
+  group(
+    'Mapping between objects with the same name from different libraries',
+    () {
+      test('UserDto to User works', () {
+        const dto = fixture.UserDto(name: 'John Wick', age: 42);
+        final converted = mappr.convert<fixture.UserDto, fixture.User>(dto);
+
+        expect(
+          converted,
+          const fixture.User(name: 'John Wick', age: 42),
+        );
+      });
+
+      test('UserDto to a1.User works', () {
+        const dto = fixture.UserDto(name: 'John Wick', age: 42);
+        final converted = mappr.convert<fixture.UserDto, fixture_a1.User>(dto);
+
+        expect(
+          converted,
+          const fixture_a1.User(name: 'John Wick', age: 42),
+        );
+      });
+
+      test('UserDto to a2.User works', () {
+        const dto = fixture.UserDto(name: 'John Wick', age: 42);
+        final converted = mappr.convert<fixture.UserDto, fixture_a2.User>(dto);
+
+        expect(
+          converted,
+          const fixture_a2.User(name: 'John Wick', age: 42),
+        );
+      });
+
+      test('a1.UserDto to User works', () {
+        const dto = fixture_a1.UserDto(name: 'John Wick', age: 42);
+        final converted = mappr.convert<fixture_a1.UserDto, fixture.User>(dto);
+
+        expect(
+          converted,
+          const fixture.User(name: 'John Wick', age: 42),
+        );
+      });
+
+      test('a1.UserDto to a1.User works', () {
+        const dto = fixture_a1.UserDto(name: 'John Wick', age: 42);
+        final converted = mappr.convert<fixture_a1.UserDto, fixture_a1.User>(dto);
+
+        expect(
+          converted,
+          const fixture_a1.User(name: 'John Wick', age: 42),
+        );
+      });
+
+      test('a1.UserDto to a2.User works', () {
+        const dto = fixture_a1.UserDto(name: 'John Wick', age: 42);
+        final converted = mappr.convert<fixture_a1.UserDto, fixture_a2.User>(dto);
+
+        expect(
+          converted,
+          const fixture_a2.User(name: 'John Wick', age: 42),
+        );
+      });
+
+      test('a2.UserDto to User works', () {
+        const dto = fixture_a2.UserDto(name: 'John Wick', age: 42);
+        final converted = mappr.convert<fixture_a2.UserDto, fixture.User>(dto);
+
+        expect(
+          converted,
+          const fixture.User(name: 'John Wick', age: 42),
+        );
+      });
+
+      test('a2.UserDto to a1.User works', () {
+        const dto = fixture_a2.UserDto(name: 'John Wick', age: 42);
+        final converted = mappr.convert<fixture_a2.UserDto, fixture_a1.User>(dto);
+
+        expect(
+          converted,
+          const fixture_a1.User(name: 'John Wick', age: 42),
+        );
+      });
+
+      test('a2.UserDto to a2.User works', () {
+        const dto = fixture_a2.UserDto(name: 'John Wick', age: 42);
+        final converted = mappr.convert<fixture_a2.UserDto, fixture_a2.User>(dto);
+
+        expect(
+          converted,
+          const fixture_a2.User(name: 'John Wick', age: 42),
+        );
+      });
+    },
+  );
+
+  group(
+    'generics',
+    () {
+      test('Holder<a1.UserDto, a2.UserDto> to a2.Holder<a1.User, a2.User> works', () {
+        const dto = fixture.Holder<fixture_a1.UserDto, fixture_a2.UserDto>(
+          first: fixture_a1.UserDto(name: 'John Wick', age: 42),
+          second: fixture_a2.UserDto(name: 'Obi-wan Kenobi', age: 69),
+        );
+        final converted = mappr.convert<fixture.Holder<fixture_a1.UserDto, fixture_a2.UserDto>,
+            fixture_a2.Holder<fixture_a1.User, fixture_a2.User>>(dto);
+
+        expect(
+          converted,
+          const fixture_a2.Holder<fixture_a1.User, fixture_a2.User>(
+            first: fixture_a1.User(name: 'John Wick', age: 42),
+            second: fixture_a2.User(name: 'Obi-wan Kenobi', age: 69),
+          ),
+        );
+      });
+    },
+  );
+
+  group(
+    'iterables',
+    () {
+      test('list works', () {
+        const dto = fixture.ListHolder<fixture.UserDto>([
+          fixture.UserDto(name: 'John Wick', age: 42),
+          fixture.UserDto(name: 'Obi-wan Kenobi', age: 69),
+        ]);
+        final converted = mappr.convert<fixture.ListHolder<fixture.UserDto>, fixture.ListHolder<fixture_a1.User>>(dto);
+
+        expect(
+          converted,
+          const fixture.ListHolder<fixture_a1.User>([
+            fixture_a1.User(name: 'John Wick', age: 42),
+            fixture_a1.User(name: 'Obi-wan Kenobi', age: 69),
+          ]),
+        );
+      });
+
+      //   MapType<MapHolder<UserDto>, MapHolder<a2.User>>(),
+      test('map works', () {
+        const dto = fixture.MapHolder<fixture.UserDto>({
+          'alpha': fixture.UserDto(name: 'John Wick', age: 42),
+          'beta': fixture.UserDto(name: 'Obi-wan Kenobi', age: 69),
+        });
+        final converted = mappr.convert<fixture.MapHolder<fixture.UserDto>, fixture.MapHolder<fixture_a2.User>>(dto);
+
+        expect(
+          converted,
+          const fixture.MapHolder<fixture_a2.User>({
+            'alpha': fixture_a2.User(name: 'John Wick', age: 42),
+            'beta': fixture_a2.User(name: 'Obi-wan Kenobi', age: 69),
+          }),
+        );
+      });
+    },
+  );
+}

--- a/packages/auto_mappr/test/integration/import_alias_test.dart
+++ b/packages/auto_mappr/test/integration/import_alias_test.dart
@@ -147,7 +147,6 @@ void main() {
         );
       });
 
-      //   MapType<MapHolder<UserDto>, MapHolder<a2.User>>(),
       test('map works', () {
         const dto = fixture.MapHolder<fixture.UserDto>({
           'alpha': fixture.UserDto(name: 'John Wick', age: 42),

--- a/packages/auto_mappr/test/integration/type_converter_test.dart
+++ b/packages/auto_mappr/test/integration/type_converter_test.dart
@@ -35,10 +35,26 @@ void main() {
   });
 
   test('nullable input type with non-nullable type converter input', () {
-    final userDto = fixture.UserDto('userId', 'accountId');
+    const userDto = fixture.UserDto('userId', 'accountId');
     final user = mappr.convert<fixture.UserDto, fixture.User>(userDto);
 
     expect(user.id, const fixture.UserId('userId'));
     expect(user.accountId, const fixture.AccountId('accountId'));
+  });
+
+  test('converter allows subtypes as input', () {
+    const user = fixture.User(fixture.UserId('userId'), fixture.AccountId('accountId'));
+    final userDto = mappr.convert<fixture.User, fixture.UserDto>(user);
+
+    expect(userDto.id, 'userId');
+    expect(userDto.accountId, 'accountId');
+  });
+
+  test('whenNull takes precedence', () {
+    const userDto = fixture.UserDto(null, null);
+    final user = mappr.convert<fixture.UserDto, fixture.User>(userDto);
+
+    expect(user.id, fixture.UserId.defaultUserId);
+    expect(user.accountId, null);
   });
 }

--- a/packages/auto_mappr/test/integration/type_converter_test.dart
+++ b/packages/auto_mappr/test/integration/type_converter_test.dart
@@ -1,0 +1,44 @@
+import 'package:test/test.dart';
+
+import 'fixture/type_converter.dart' as fixture;
+
+void main() {
+  late final fixture.Mappr mappr;
+
+  setUpAll(() {
+    mappr = fixture.Mappr();
+  });
+
+  test('use most specific type converter', () {
+    final dto = fixture.DateDto(
+      dateTimeA: '2023',
+      dateTimeB: '2023',
+      dateTimeC: '2023-05-02T14:44:51.510',
+    );
+    final dto2 = fixture.DateDto2(
+      dateTimeA: '2023-05-02T14:44:51.510',
+      dateTimeB: '2023-05-02T14:44:51.510',
+    );
+    final domain1 = mappr.convert<fixture.DateDto, fixture.DateDomain>(dto);
+    final domain2 = mappr.convert<fixture.DateDto2, fixture.DateDomain>(dto2);
+
+    // defined on field level
+    expect(domain1.dateTimeA, fixture.Mappr.tryParseFirstOfDecemberInYear(dto.dateTimeA));
+
+    // defined on type level
+    expect(domain1.dateTimeB, fixture.Mappr.parseSecondOfDecemberInYear(dto.dateTimeB));
+    expect(domain1.dateTimeC, fixture.Mappr.parseSecondOfDecemberInYear(dto.dateTimeC));
+
+    // defined on mappr level
+    expect(domain2.dateTimeA, fixture.Mappr.parseISO8601(dto2.dateTimeA));
+    expect(domain2.dateTimeB, fixture.Mappr.parseISO8601(dto2.dateTimeB));
+  });
+
+  test('nullable input type with non-nullable type converter input', () {
+    final userDto = fixture.UserDto('userId', 'accountId');
+    final user = mappr.convert<fixture.UserDto, fixture.User>(userDto);
+
+    expect(user.id, const fixture.UserId('userId'));
+    expect(user.accountId, const fixture.AccountId('accountId'));
+  });
+}

--- a/packages/auto_mappr_annotation/lib/auto_mappr_annotation.dart
+++ b/packages/auto_mappr_annotation/lib/auto_mappr_annotation.dart
@@ -5,3 +5,4 @@ export 'src/field.dart';
 export 'src/iterable_nullable_extension.dart';
 export 'src/map_extension.dart';
 export 'src/map_type.dart';
+export 'src/type_converter.dart';

--- a/packages/auto_mappr_annotation/lib/src/auto_mappr.dart
+++ b/packages/auto_mappr_annotation/lib/src/auto_mappr.dart
@@ -1,10 +1,13 @@
-import 'package:auto_mappr_annotation/src/map_type.dart';
+import 'package:auto_mappr_annotation/auto_mappr_annotation.dart';
 
 /// Annotates class which will be used as base for generated mappr.
 class AutoMappr {
   /// List of mapprs.
   final List<MapType<Object?, Object?>> mappers;
 
+  /// List of [TypeConverter]s.
+  final List<TypeConverter<Object?, Object?>> types;
+
   /// Constructs AutoMap.
-  const AutoMappr(this.mappers);
+  const AutoMappr(this.mappers, {this.types = const []});
 }

--- a/packages/auto_mappr_annotation/lib/src/auto_mappr.dart
+++ b/packages/auto_mappr_annotation/lib/src/auto_mappr.dart
@@ -5,8 +5,11 @@ class AutoMappr {
   /// List of mapprs.
   final List<MapType<Object?, Object?>> mappers;
 
-  /// List of [TypeConverter]s.
-  final List<TypeConverter<Object?, Object?>> types;
+  /// Configure type mappings.
+  ///
+  /// Accepts a list of `Target Function(Source)` functions
+  /// and or a [TypeConverter] instances.
+  final List<Object> types;
 
   /// Constructs AutoMap.
   const AutoMappr(this.mappers, {this.types = const []});

--- a/packages/auto_mappr_annotation/lib/src/field.dart
+++ b/packages/auto_mappr_annotation/lib/src/field.dart
@@ -1,5 +1,4 @@
 import 'package:auto_mappr_annotation/src/type_converter.dart';
-
 /// Mapping configuration of target object's field.
 class Field {
   /// Which field is mapped.
@@ -27,8 +26,11 @@ class Field {
   /// Note that [custom] has priority.
   final String? from;
 
-  /// Source type should be converted to target type using [type].
-  final TypeConverter<Object?, Object?>? type;
+  /// Configure type mapping.
+  ///
+  /// Accepts `Target Function(Source)` function or a [TypeConverter] instance.
+  // ignore: no-object-declaration, correct usage
+  final Object? type;
 
   /// Universal constructor.
   const Field(

--- a/packages/auto_mappr_annotation/lib/src/field.dart
+++ b/packages/auto_mappr_annotation/lib/src/field.dart
@@ -32,6 +32,9 @@ class Field {
   // ignore: no-object-declaration, correct usage
   final Object? type;
 
+  /// Force null check on source [field].
+  final bool nullChecked;
+
   /// Universal constructor.
   const Field(
     this.field, {
@@ -40,6 +43,7 @@ class Field {
     this.ignore = false,
     this.whenNull,
     this.type,
+    this.nullChecked = false,
   });
 
   /// Field renaming using [from] or assigning default value with [whenNull].
@@ -48,6 +52,7 @@ class Field {
     required this.from,
     this.whenNull,
     this.type,
+    this.nullChecked = false,
   })  : custom = null,
         ignore = false;
 
@@ -56,14 +61,26 @@ class Field {
     this.field, {
     required this.custom,
     this.whenNull,
+    this.type,
+    this.nullChecked = false,
   })  : from = null,
-        ignore = false,
-        type = null;
+        ignore = false;
 
   /// Field ignoring.
   const Field.ignore(
     this.field,
   )   : ignore = true,
+        from = null,
+        custom = null,
+        whenNull = null,
+        type = null,
+        nullChecked = false;
+
+  /// Field nullChecked.
+  const Field.nullChecked(
+    this.field,
+  )   : nullChecked = true,
+        ignore = false,
         from = null,
         custom = null,
         whenNull = null,

--- a/packages/auto_mappr_annotation/lib/src/field.dart
+++ b/packages/auto_mappr_annotation/lib/src/field.dart
@@ -1,3 +1,5 @@
+import 'package:auto_mappr_annotation/src/type_converter.dart';
+
 /// Mapping configuration of target object's field.
 class Field {
   /// Which field is mapped.
@@ -25,6 +27,9 @@ class Field {
   /// Note that [custom] has priority.
   final String? from;
 
+  /// Source type should be converted to target type using [type].
+  final TypeConverter<Object?, Object?>? type;
+
   /// Universal constructor.
   const Field(
     this.field, {
@@ -32,6 +37,7 @@ class Field {
     this.custom,
     this.ignore = false,
     this.whenNull,
+    this.type,
   });
 
   /// Field renaming using [from] or assigning default value with [whenNull].
@@ -39,6 +45,7 @@ class Field {
     this.field, {
     required this.from,
     this.whenNull,
+    this.type,
   })  : custom = null,
         ignore = false;
 
@@ -48,7 +55,8 @@ class Field {
     required this.custom,
     this.whenNull,
   })  : from = null,
-        ignore = false;
+        ignore = false,
+        type = null;
 
   /// Field ignoring.
   const Field.ignore(
@@ -56,5 +64,6 @@ class Field {
   )   : ignore = true,
         from = null,
         custom = null,
-        whenNull = null;
+        whenNull = null,
+        type = null;
 }

--- a/packages/auto_mappr_annotation/lib/src/map_type.dart
+++ b/packages/auto_mappr_annotation/lib/src/map_type.dart
@@ -1,9 +1,12 @@
-import 'package:auto_mappr_annotation/src/field.dart';
+import 'package:auto_mappr_annotation/auto_mappr_annotation.dart';
 
 /// Configured mapping from [SOURCE] to [TARGET].
 class MapType<SOURCE, TARGET> {
   /// Configuration for [TARGET]'s fields.
   final List<Field> fields;
+
+  /// Configuration for mapping types between [SOURCE] and [TARGET].
+  final List<TypeConverter<Object?, Object?>> types;
 
   /// Provides default value if SOURCE is null.
   ///
@@ -25,6 +28,7 @@ class MapType<SOURCE, TARGET> {
   /// Constructs mapping between [SOURCE] and [TARGET] types.
   const MapType({
     this.fields = const [],
+    this.types = const [],
     this.whenSourceIsNull,
     this.constructor,
   });

--- a/packages/auto_mappr_annotation/lib/src/map_type.dart
+++ b/packages/auto_mappr_annotation/lib/src/map_type.dart
@@ -5,8 +5,11 @@ class MapType<SOURCE, TARGET> {
   /// Configuration for [TARGET]'s fields.
   final List<Field> fields;
 
-  /// Configuration for mapping types between [SOURCE] and [TARGET].
-  final List<TypeConverter<Object?, Object?>> types;
+  /// Configure type mappings.
+  ///
+  /// Accepts a list of `Target Function(Source)` functions
+  /// and or a [TypeConverter] instances.
+  final List<Object> types;
 
   /// Provides default value if SOURCE is null.
   ///

--- a/packages/auto_mappr_annotation/lib/src/type_converter.dart
+++ b/packages/auto_mappr_annotation/lib/src/type_converter.dart
@@ -1,0 +1,10 @@
+/// {@template type_converter}
+/// Configure Type Mapping from [SOURCE] to [TARGET].
+/// {@endtemplate}
+class TypeConverter<SOURCE, TARGET> {
+  /// Mapping function to convert [SOURCE] to [TARGET].
+  final TARGET Function(SOURCE source) convert;
+
+  /// {@macro type_converter}
+  const TypeConverter(this.convert);
+}

--- a/packages/auto_mappr_annotation/lib/src/type_converter.dart
+++ b/packages/auto_mappr_annotation/lib/src/type_converter.dart
@@ -1,10 +1,14 @@
-/// {@template type_converter}
-/// Configure Type Mapping from [SOURCE] to [TARGET].
-/// {@endtemplate}
-class TypeConverter<SOURCE, TARGET> {
-  /// Mapping function to convert [SOURCE] to [TARGET].
-  final TARGET Function(SOURCE source) convert;
+/// Configure Type Mapping.
+class TypeConverter {
+  /// Function that converts from SOURCE to TARGET.
+  ///
+  /// Acceps `TARGET Function(SOURCE)` function.
+  // ignore: no-object-declaration, correct usage
+  final Object? convert;
 
-  /// {@macro type_converter}
-  const TypeConverter(this.convert);
+  /// Name of the field to which this converter is constrained.
+  final String? field;
+
+  /// Construct a [TypeConverter] instance.
+  const TypeConverter(this.convert, {this.field});
 }


### PR DESCRIPTION
Close #60 

This is just a rough first implementation of the feature with very few tests etc. etc.

I'm open for any input about how things should work.

Another addition I want to propose is specifying field names (or even patterns) for Type Converters. This would allow globally specifying a `UserId` `TypeConverter` that converts from `String` to `UserId` if the field has the name `userId`.