### PR TITLE
Fix reverse with type converters

### DIFF
--- a/packages/auto_mappr/CHANGELOG.md
+++ b/packages/auto_mappr/CHANGELOG.md
@@ -1,5 +1,8 @@
 [//]: # (## Unreleased)
 
+## 2.0.1
+- Fix type converters when used with reverse mappings.
+
 ## 2.0.0
 - **Breaking**: Allow "absorbing" modules using `includes` on `@AutoMappr`. Previous `modules` is now `delegates`. [#117](https://github.com/netglade/auto_mappr/pull/117)
 - **Breaking**: Remove shared AutoMappr builder that used PartBuilder, now `.auto_mappr.dart` is generated using LibraryBuilder. [#117](https://github.com/netglade/auto_mappr/pull/117)

--- a/packages/auto_mappr/lib/src/builder/map_bodies/class_body_builder.dart
+++ b/packages/auto_mappr/lib/src/builder/map_bodies/class_body_builder.dart
@@ -115,6 +115,7 @@ class ClassBodyBuilder extends MapBodyBuilderBase {
           targetField: targetField,
           targetConstructorParam: constructorAssignment,
           fieldMapping: mapping.tryGetFieldMapping(targetField.displayName),
+          typeConverters: mapping.typeConverters,
         );
 
         mappedTargetConstructorParams.add(sourceAssignment);
@@ -165,6 +166,7 @@ class ClassBodyBuilder extends MapBodyBuilderBase {
             targetField: targetField,
             fieldMapping: fieldMapping,
             targetConstructorParam: constructorAssignment,
+            typeConverters: mapping.typeConverters,
           ),
         );
       }
@@ -246,6 +248,7 @@ class ClassBodyBuilder extends MapBodyBuilderBase {
               assignment: SourceAssignment(
                 sourceField: sourceField,
                 targetField: targetField,
+                typeConverters: mapping.typeConverters,
               ),
               usedNullableMethodCallback: usedNullableMethodCallback,
             ).build(),

--- a/packages/auto_mappr/lib/src/builder/value_assignment_builder.dart
+++ b/packages/auto_mappr/lib/src/builder/value_assignment_builder.dart
@@ -44,6 +44,16 @@ class ValueAssignmentBuilder {
         .property(sourceField.name);
 
     final assignmentBuilders = [
+      // Type converter.
+      TypeConverterBuilder(
+        assignment: assignment,
+        mapperConfig: mapperConfig,
+        mapping: mapping,
+        usedNullableMethodCallback: usedNullableMethodCallback,
+        source: assignment.sourceType!,
+        target: assignment.targetType,
+        convertMethodArgument: rightSide,
+      ),
       // Iterable.
       IterableAssignmentBuilder(
         assignment: assignment,
@@ -67,16 +77,6 @@ class ValueAssignmentBuilder {
       ),
       // Nested object.
       NestedObjectAssignmentBuilder(
-        assignment: assignment,
-        mapperConfig: mapperConfig,
-        mapping: mapping,
-        usedNullableMethodCallback: usedNullableMethodCallback,
-        source: assignment.sourceType!,
-        target: assignment.targetType,
-        convertMethodArgument: rightSide,
-      ),
-      // Type converter for primitive type.
-      TypeConverterBuilder(
         assignment: assignment,
         mapperConfig: mapperConfig,
         mapping: mapping,

--- a/packages/auto_mappr/lib/src/generator/auto_mappr_generator.dart
+++ b/packages/auto_mappr/lib/src/generator/auto_mappr_generator.dart
@@ -167,6 +167,7 @@ class AutoMapprGenerator extends GeneratorForAnnotation<annotation.AutoMappr> {
                 source: targetType,
                 target: sourceType,
                 fieldMappings: fieldMappings ?? [],
+                typeConverters: [..._toTypeConverters(mapTypeConverters), ...globalConverters],
                 whenSourceIsNullExpression: whenSourceIsNull,
                 constructor: constructor,
                 ignoreFieldNull: ignoreFieldNull,

--- a/packages/auto_mappr/pubspec.yaml
+++ b/packages/auto_mappr/pubspec.yaml
@@ -1,6 +1,6 @@
 name: auto_mappr
 description: Code generation for mapping between different objects with ease.
-version: 2.0.0
+version: 2.0.1
 repository: https://github.com/netglade/auto_mappr
 issue_tracker: https://github.com/netglade/auto_mappr/issues
 screenshots:

--- a/packages/auto_mappr/test/integration/fixture/type_converters.dart
+++ b/packages/auto_mappr/test/integration/fixture/type_converters.dart
@@ -17,10 +17,15 @@ import 'type_converters/module_alpha.dart';
     MapType<InListDto, InList>(),
     MapType<InMapDto, InMap>(),
     MapType<IncludesDto, Includes>(),
+    // Post w/ reverse.
+    MapType<PostDto, Post>(reverse: true),
   ],
   converters: [
     TypeConverter<String, Value<String>>(Mappr.stringToValueString),
     TypeConverter<Object, Value<Object>>(Mappr.objectToValueObject2),
+    // Post w/ reverse.
+    userDtoConverter,
+    userConverter,
   ],
   includes: [MapprAlpha()],
 )
@@ -78,7 +83,11 @@ class NormalFieldDto {
   final String xString;
   final bool normalBool;
 
-  const NormalFieldDto({required this.xInt, required this.xString, required this.normalBool});
+  const NormalFieldDto({
+    required this.xInt,
+    required this.xString,
+    required this.normalBool,
+  });
 }
 
 class NormalField with EquatableMixin {
@@ -99,7 +108,11 @@ class InListDto {
   final String xString;
   final bool normalBool;
 
-  const InListDto({required this.xInt, required this.xString, required this.normalBool});
+  const InListDto({
+    required this.xInt,
+    required this.xString,
+    required this.normalBool,
+  });
 }
 
 class InList with EquatableMixin {
@@ -161,3 +174,46 @@ class Value<T> with EquatableMixin {
 
   const Value(this.value);
 }
+
+// Post w/ reverse.
+
+class Post with EquatableMixin {
+  final User user;
+
+  @override
+  List<Object?> get props => [user];
+
+  const Post({required this.user});
+}
+
+class PostDto with EquatableMixin {
+  final UserDto user;
+
+  @override
+  List<Object?> get props => [user];
+
+  const PostDto({required this.user});
+}
+
+class User with EquatableMixin {
+  final String id;
+
+  @override
+  List<Object?> get props => [id];
+
+  const User({required this.id});
+}
+
+class UserDto with EquatableMixin {
+  final String id;
+
+  @override
+  List<Object?> get props => [id];
+
+  const UserDto({required this.id});
+}
+
+const userDtoConverter = TypeConverter(userDtoToUser);
+const userConverter = TypeConverter(userToUserDto);
+UserDto userToUserDto(User source) => UserDto(id: source.id);
+User userDtoToUser(UserDto source) => User(id: source.id);

--- a/packages/auto_mappr/test/integration/type_converters_test.dart
+++ b/packages/auto_mappr/test/integration/type_converters_test.dart
@@ -72,4 +72,20 @@ void main() {
 
     expect(converted, equals(const fixture.Includes(false)));
   });
+
+  group('with reverse', () {
+    test('Dto to entity', () {
+      const dto = fixture.PostDto(user: fixture.UserDto(id: 'alpha123'));
+      final converted = mappr.convert<fixture.PostDto, fixture.Post>(dto);
+
+      expect(converted, equals(const fixture.Post(user: fixture.User(id: 'alpha123'))));
+    });
+
+    test('Entity to dto', () {
+      const dto = fixture.Post(user: fixture.User(id: 'beta123'));
+      final converted = mappr.convert<fixture.Post, fixture.PostDto>(dto);
+
+      expect(converted, equals(const fixture.PostDto(user: fixture.UserDto(id: 'beta123'))));
+    });
+  });
 }


### PR DESCRIPTION
Following https://github.com/netglade/auto_mappr/issues/60#issuecomment-1742090999, this PR fixes type converters when reverse is used (we forgot to pass them).

It also moves type converters to be the first thing to be checked, since it makes sense. (so the order for value builder now is type converters, iterable, map, record, nested)