### PR TITLE
Bump analyzer to 10.0.0

### DIFF
--- a/packages/auto_mappr/pubspec.yaml
+++ b/packages/auto_mappr/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ^3.9.0
 
 dependencies:
-  analyzer: ^10.0.0 # freezed is at >=9.0.0 <11.0.0
+  analyzer: '>=9.0.0 <11.0.0' # Same as freezed
   auto_mappr_annotation: ^2.3.0
   build: ^4.0.0
   built_collection: ^5.1.1

--- a/packages/auto_mappr/pubspec.yaml
+++ b/packages/auto_mappr/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   sdk: ^3.9.0
 
 dependencies:
-  analyzer: ^9.0.0 # Same as freezed
+  analyzer: ^10.0.0 # freezed is at >=9.0.0 <11.0.0
   auto_mappr_annotation: ^2.3.0
   build: ^4.0.0
   built_collection: ^5.1.1


### PR DESCRIPTION
## Problem
Users cannot upgrade to `drift_dev` ^2.32.0 or `sqlite3` ^3.0.0 because `auto_mappr` is strictly pinned to `analyzer ^9.0.0`. This causes a version solving failure in the Dart pub resolver.

## Solution
* Updated `pubspec.yaml` to allow `analyzer: ^10.0.0`.

## Verification
* [x] Ran `dart pub get` successfully.
* [x] All 395 existing tests passed (`+395: All tests passed!`).
* [x] Verified via path dependency in a local project using `drift ^2.32.1`and `sqlite3: ^3.2.0`.